### PR TITLE
Clean up footer, add Donate Btn to header

### DIFF
--- a/src/components/Footer.js
+++ b/src/components/Footer.js
@@ -2,12 +2,8 @@ import React from "react"
 import footerStyles from "../css/footer.module.css"
 import Logo from "../assets/pdap_acronym_final.svg"
 import Link from "../components/Link"
-import SubscribeButton from "./SubscribeButton"
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome"
-import {
-  faLinkedin,
-  faSlack
-} from "@fortawesome/free-brands-svg-icons"
+import { faGithub, faLinkedin, faSlack } from "@fortawesome/free-brands-svg-icons"
 import PaypalDonate from "./PaypalDonate"
 
 export default function Footer() {
@@ -17,9 +13,20 @@ export default function Footer() {
         <Logo className={footerStyles.footer__logo__image} title="Police Data Accessibility Project - Home" />
       </Link>
       <div className={footerStyles.footer__content}>
-        <SubscribeButton buttonText="Subscribe to our newsletter" />
         <PaypalDonate />
         <div className={footerStyles.social__icons}>
+          <a
+            href="https://github.com/Police-Data-Accessibility-Project/Police-Data-Accessibility-Project/"
+            target="_blank"
+            rel="noreferrer"
+            alt="Police Data Accessibility Project - GitHub"
+            className={footerStyles.social__icon}
+          >
+            <FontAwesomeIcon
+              icon={faGithub}
+              title="Police Data Accessibility Project - Github"
+            />
+          </a>
           <a
             href="https://www.linkedin.com/company/police-data-accessibility-project/"
             target="_blank"
@@ -36,7 +43,10 @@ export default function Footer() {
             alt="Police Data Accessibility Project - Slack"
             className={footerStyles.social__icon}
           >
-            <FontAwesomeIcon icon={faSlack} title="Police Data Accessibility Project Slack" />
+            <FontAwesomeIcon
+              icon={faSlack}
+              title="Police Data Accessibility Project - Slack"
+            />
           </a>
         </div>
         <span className={footerStyles.copyright}>

--- a/src/components/Navbar.js
+++ b/src/components/Navbar.js
@@ -4,7 +4,8 @@ import Link from "./Link"
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome"
 import { faBars, faTimes } from "@fortawesome/free-solid-svg-icons"
 
-import navStyles from "../css/nav.module.css"
+import * as navStyles from "../css/nav.module.css"
+import PaypalDonate from "./PaypalDonate"
 import NewsletterSignup from "./forms/NewsletterSignup"
 import SubscribeButton from "./SubscribeButton"
 
@@ -64,6 +65,7 @@ export default class Navbar extends React.Component {
               </Link>
             )
           })}
+          <PaypalDonate />
         </div>
 
       </nav>

--- a/src/components/PaypalDonate.js
+++ b/src/components/PaypalDonate.js
@@ -2,7 +2,7 @@ import React from "react"
 const PaypalDonate = () => {
     var hostedButtonIdVal = process.env.GATSBY_PAYPAL_HOSTED_BUTTON_ID
     return (
-        <form action="https://www.paypal.com/donate" method="post" target="_top">
+        <form action="https://www.paypal.com/donate" method="post" target="_blank">
             <input type="hidden" name="hosted_button_id" value={hostedButtonIdVal} />
             <input type="image" src="https://www.paypalobjects.com/en_US/i/btn/btn_donate_LG.gif" border="0" name="submit" title="PayPal - The safer, easier way to pay online!" alt="Donate with PayPal button" />
             <img alt="" border="0" src="https://www.paypal.com/en_US/i/scr/pixel.gif" width="1" height="1" />


### PR DESCRIPTION
1. Removed the Newsletter Subscription button from footer allow more focus on Donate button. Added a GitHub icon linked to our repo.
2. Added PayPal Donate button to header.
3. Tweaked PayPal Donate button so that it opens into a new tab. Current behavior opens in same tab.

1
![image](https://user-images.githubusercontent.com/47481188/112405161-f9fa1580-8cce-11eb-96ca-6d2c29e28adc.png)

2
![image](https://user-images.githubusercontent.com/47481188/112405249-27df5a00-8ccf-11eb-8156-6ca66de3b743.png)