### PR TITLE
Renamed master to main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [ master ]
+    branches: [ main ]
   pull_request:
-    branches: [ master ]
+    branches: [ main ]
 
 jobs:
   test:


### PR DESCRIPTION
This seemed like the right thing to do, is that right?

Should we delete deploy.yml too? Looks commented out.