### PR TITLE
replaced link to blog

### DIFF
--- a/contribute.html
+++ b/contribute.html
@@ -32,7 +32,7 @@
       <a href="index.html" class="nav-link w-nav-link">Home</a>
       <a href="faq.html" class="nav-link w-nav-link">FAQ</a>
       <a href="https://docs.pdap.io/" class="nav-link w-nav-link">Docs</a>
-      <a href="http://blog.pdap.io/" class="nav-link w-nav-link">Blog</a>
+      <a href="https://docs.pdap.io/updates/blog" class="nav-link w-nav-link">Blog</a>
       <a href="contribute.html" aria-current="page" class="nav-link w-nav-link w--current">Contribute</a>
     </nav>
   </div>

--- a/faq.html
+++ b/faq.html
@@ -32,7 +32,7 @@
       <a href="index.html" class="nav-link w-nav-link">Home</a>
       <a href="faq.html" aria-current="page" class="nav-link w-nav-link w--current">FAQ</a>
       <a href="https://docs.pdap.io/" class="nav-link w-nav-link">Docs</a>
-      <a href="http://blog.pdap.io/" class="nav-link w-nav-link">Blog</a>
+      <a href="https://docs.pdap.io/updates/blog" class="nav-link w-nav-link">Blog</a>
       <a href="contribute.html" class="nav-link w-nav-link">Contribute</a>
     </nav>
   </div>

--- a/index.html
+++ b/index.html
@@ -30,7 +30,7 @@
       <a href="index.html" aria-current="page" class="nav-link w-nav-link w--current">Home</a>
       <a href="faq.html" class="nav-link w-nav-link">FAQ</a>
       <a href="https://docs.pdap.io/" class="nav-link w-nav-link">Docs</a>
-      <a href="http://blog.pdap.io/" class="nav-link w-nav-link">Blog</a>
+      <a href="https://docs.pdap.io/updates/blog" class="nav-link w-nav-link">Blog</a>
       <a href="contribute.html" class="nav-link w-nav-link">Contribute</a>
     </nav>
   </div>

--- a/style-guide.html
+++ b/style-guide.html
@@ -33,7 +33,7 @@
         <a href="index.html" class="nav-link w-nav-link">Home</a>
         <a href="faq.html" class="nav-link w-nav-link">FAQ</a>
         <a href="https://docs.pdap.io/" class="nav-link w-nav-link">Docs</a>
-        <a href="http://blog.pdap.io/" class="nav-link w-nav-link">Blog</a>
+        <a href="https://docs.pdap.io/updates/blog" class="nav-link w-nav-link">Blog</a>
         <a href="contribute.html" class="nav-link w-nav-link">Contribute</a>
       </nav>
     </div>


### PR DESCRIPTION
The old blog is great but has some problems:
- out of sync style wise with the rest of the site
- using gatsby, which the rest of the site wasn't using
- no one could make blog posts or publish it except Eric

I'm moving it back to docs because:
- it's free and requires no code maintenance or hosting
- anyone with a github or gitbook account can make a blog post
- instant deployment 