### PR TITLE
Add airtable Data Sources view

### DIFF
--- a/about.html
+++ b/about.html
@@ -54,17 +54,17 @@
     </div>
     <nav role="navigation" class="nav-menu w-nav-menu">
       <a href="index.html" class="nav-link w-nav-link">Home</a>
-      <a href="about.html" aria-current="page" class="nav-link w-nav-link w--current">About</a>
+      <a href="data-sources.html" class="nav-link w-nav-link">Data Sources</a>
       <a href="contribute.html" class="nav-link w-nav-link">Contribute</a>
+      <a href="about.html" aria-current="page" class="nav-link w-nav-link w--current">About</a>
       <a href="https://docs.pdap.io/" class="nav-link w-nav-link">Docs</a>
-      <a href="https://newsletter.pdap.io" class="nav-link w-nav-link">Newsletter</a>
       <a href="jobs.html" class="nav-link w-nav-link">Jobs</a>
     </nav>
   </div>
   <div class="wf-section">
     <div class="w-container">
       <h1>About</h1>
-      <p>Email us at <a href="mailto:contact@pdap.io">contact@pdap.io</a> or <a href="https://discord.gg/wMqex8nKZJ">join the Discord</a> to get in touch.</p>
+      <p>Email us at <a href="mailto:contact@pdap.io">contact@pdap.io</a> or <a href="https://discord.gg/wMqex8nKZJ">join the Discord</a> to get in touch. We also have a <a href="https://newsletter.pdap.io">newsletter</a>.</p>
       <h2>Strategy & Goals</h2>
       <p>The criminal legal system is decentralized; our approach embraces this, working locally first to make an immediate impact on transparency and access to data.</p>
       <p>Our data is crowdsourced in collaboration with the community of people who need police data for their work.</p>
@@ -86,7 +86,7 @@
           <p>PDAP becomes a trusted hub for directly accessing police data.</p>
           <p>To get here, we'll need to be able to store large amounts of data responsibly. We'll need robust hosting infrastructure and operations support. In the meantime, we're learning about our users and how we can make the biggest impact.</p>
         </div>
-        <p class="grid-span-3">To see our plans in more detail, check out our <a href="https://github.com/orgs/Police-Data-Accessibility-Project/projects/17">roadmap</a> and <a href="https://github.com/Police-Data-Accessibility-Project/planning/milestones?direction=asc&sort=due_date&state=open">long-term milestones</a>.</p>
+        <p class="grid-span-3">To see our code-related plans and progress, check out our <a href="https://github.com/orgs/Police-Data-Accessibility-Project/projects/17">roadmap</a> and <a href="https://github.com/Police-Data-Accessibility-Project/planning/milestones?direction=asc&sort=due_date&state=open">long-term milestones</a>.</p>
       </div>
       <div class="w-layout-grid grid top-45">
         <h2 class="grid-span-2">Non-profit &amp; community roles</h2>

--- a/about.html
+++ b/about.html
@@ -152,7 +152,7 @@
   <div class="footer wf-section">
     <div class="container w-container">
       <div class="footer-actions">
-        <a href="https://github.com/orgs/Police-Data-Accessibility-Project/projects/17" class="button button-footer w-button">GitHub</a>
+        <a href="https://github.com/orgs/Police-Data-Accessibility-Project" class="button button-footer w-button">GitHub</a>
         <a href="https://discord.gg/wMqex8nKZJ" class="button button-footer w-button">Discord</a>
         <a href="https://www.linkedin.com/company/pdap" class="button button-footer w-button">LinkedIn</a>
       </div>

--- a/contribute.html
+++ b/contribute.html
@@ -72,7 +72,9 @@
       <h1>How to contribute</h1>
       <p>Thank you for your interest in helping our mission!
       <div class="w-row">
-        <h2>Give money</h2>
+        <div class="w-col w-col-12">
+          <h2>Donate</h2>
+        </div>
         <div class="w-col w-col-6 bottom-20">
             <script src="https://donorbox.org/widget.js" paypalExpress="false"></script><iframe src="https://donorbox.org/embed/pdap" name="donorbox" allowpaymentrequest="allowpaymentrequest" seamless="seamless" frameborder="0" scrolling="no" height="900px" width="100%" style="max-width: 500px; min-width: 250px; max-height:none!important"></iframe>
         </div>

--- a/contribute.html
+++ b/contribute.html
@@ -60,10 +60,10 @@
     </div>
     <nav role="navigation" class="nav-menu w-nav-menu">
       <a href="index.html" class="nav-link w-nav-link">Home</a>
-      <a href="about.html" class="nav-link w-nav-link">About</a>
+      <a href="data-sources.html" class="nav-link w-nav-link">Data Sources</a>
       <a href="contribute.html" aria-current="page" class="nav-link w-nav-link w--current">Contribute</a>
+      <a href="about.html" class="nav-link w-nav-link">About</a>
       <a href="https://docs.pdap.io/" class="nav-link w-nav-link">Docs</a>
-      <a href="https://newsletter.pdap.io" class="nav-link w-nav-link">Newsletter</a>
       <a href="jobs.html" class="nav-link w-nav-link">Jobs</a>
     </nav>
   </div>

--- a/contribute.html
+++ b/contribute.html
@@ -112,7 +112,7 @@
   <div class="footer wf-section">
     <div class="container w-container">
       <div class="footer-actions">
-        <a href="https://github.com/orgs/Police-Data-Accessibility-Project/projects/17" class="button button-footer w-button">GitHub</a>
+        <a href="https://github.com/orgs/Police-Data-Accessibility-Project" class="button button-footer w-button">GitHub</a>
         <a href="https://discord.gg/wMqex8nKZJ" class="button button-footer w-button">Discord</a>
         <a href="https://www.linkedin.com/company/pdap" class="button button-footer w-button">LinkedIn</a>
       </div>

--- a/css/custom-styles.css
+++ b/css/custom-styles.css
@@ -188,7 +188,7 @@ strong {
   padding-right: 25px;
   padding-left: 25px;
   background-color: #d5a23c;
-  font-size: 22px;
+  font-size: 20px;
   font-weight: 600;
   text-align: center;
 }
@@ -399,6 +399,10 @@ strong {
   max-width: 30ch;
 }
 
+.airtable-box {
+  margin: 40px;
+}
+
 @media screen and (max-width: 991px) {
   body {
     padding-right: 10px;
@@ -501,6 +505,10 @@ strong {
     grid-column-start: span 1;
     -ms-grid-column-span: 1;
     grid-column-end: span 1;
+  }
+
+  .airtable-box {
+    margin: 10px;
   }
 
 }

--- a/data-sources.html
+++ b/data-sources.html
@@ -3,9 +3,9 @@
 <html>
 <head>
   <meta charset="utf-8">
-  <title>Style Guide</title>
-  <meta content="Style Guide" property="og:title">
-  <meta content="Style Guide" property="twitter:title">
+  <title>Data Sources</title>
+  <meta content="Data Sources" property="og:title">
+  <meta content="Data Sources" property="twitter:title">
   <meta content="width=device-width, initial-scale=1" name="viewport">
   <meta content="Webflow" name="generator">
   <link href="css/normalize.css" rel="stylesheet" type="text/css">
@@ -50,21 +50,18 @@
   </div>
   <div class="wf-section">
     <div class="w-container">
-      <h1 class="shout">Shout</h1>
-      <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Suspendisse varius enim in eros elementum tristique. Duis cursus, mi quis viverra ornare, eros dolor interdum nulla, ut commodo diam libero vitae erat. Aenean faucibus nibh et justo cursus id rutrum lorem imperdiet. Nunc ut sem vitae risus tristique posuere.</p>
-      <h1>Heading 1</h1>
-      <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Suspendisse varius enim in eros elementum tristique. Duis cursus, mi quis viverra ornare, eros dolor interdum nulla, ut commodo diam libero vitae erat. Aenean faucibus nibh et justo cursus id rutrum lorem imperdiet. </p>
-      <p>Nunc ut sem vitae risus tristique posuere.</p>
-      <h2>Heading 2</h2>
-      <p>Enim in eros elementum tristique. Duis cursus, mi quis viverra ornare.</p>
-      <h3>Heading 3</h3>
-      <p>Nunc ut sem vitae risus tristique posuere.</p>
-      <h4>Heading 4</h4>
-      <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Suspendisse varius enim in eros elementum tristique. Duis cursus, mi quis viverra ornare, eros dolor interdum nulla, ut commodo diam libero vitae erat. Aenean faucibus nibh et justo cursus id rutrum lorem imperdiet. Nunc ut sem vitae risus tristique posuere.</p>
-      <h5>Heading 5</h5>
-      <p>Nunc ut sem vitae risus tristique posuere.</p>
-      <h6>Heading 6</h6>
-      <p>Nunc ut sem vitae risus tristique posuere.</p>
+      <h1>Data Sources</h1>
+      <p>The start of any research or investigation is a source of data. This database is always growing, thanks to community contributions.</p>
+      <p>At the top of the view below, you have tools for filtering, grouping, and sorting. By default, freshly approved sources are at the top. <strong>Try filtering by your state or county!</strong></p>
+      <p>If you find an inaccuracy, please reach out to <a href="mailto:contact@pdap.io">contact@pdap.io</a> to correct the record.</p>
+      <div>
+        <a href="https://airtable.com/shrJafakrcmTxHU2i" class="button w-button">Submit a Data Source</a>
+        <a href="https://airtable.com/shr43ihbyM8DDkKx4" class="button w-button">View Agencies</a>
+        <a href="https://docs.pdap.io/activities/data-sources" class="button w-button">Learn more in the docs</a>
+      </div>
+    </div>
+    <div class="airtable-box">
+        <iframe class="airtable-embed" src="https://airtable.com/embed/shrUAtA8qYasEaepI?backgroundColor=gray&viewControls=on" frameborder="0" onmousewheel="scroll" width="100%" height="750" style="background: transparent; border: 1px solid #512a4f;"></iframe>
     </div>
   </div>
   <div class="footer wf-section">

--- a/data-sources.html
+++ b/data-sources.html
@@ -51,7 +51,7 @@
   <div class="wf-section">
     <div class="w-container">
       <h1>Data Sources</h1>
-      <p>The start of any research or investigation is a source of data. This database is always growing, thanks to community contributions.</p>
+      <p>The start of any research or investigation is a source of data. Each row represents a source of public records about an agency in the criminal legal system. This database is always growing, thanks to community contributions.</p>
       <p>At the top of the view below, you have tools for filtering, grouping, and sorting. By default, freshly approved sources are at the top. <strong>Try filtering by your state or county!</strong></p>
       <p>If you find an inaccuracy, please reach out to <a href="mailto:contact@pdap.io">contact@pdap.io</a> to correct the record.</p>
       <div>

--- a/index.html
+++ b/index.html
@@ -153,7 +153,7 @@
   <div class="footer wf-section">
     <div class="container w-container">
       <div class="footer-actions">
-        <a href="https://github.com/orgs/Police-Data-Accessibility-Project/projects/17" class="button button-footer w-button">GitHub</a>
+        <a href="https://github.com/orgs/Police-Data-Accessibility-Project" class="button button-footer w-button">GitHub</a>
         <a href="https://discord.gg/wMqex8nKZJ" class="button button-footer w-button">Discord</a>
         <a href="https://www.linkedin.com/company/pdap" class="button button-footer w-button">LinkedIn</a>
       </div>

--- a/index.html
+++ b/index.html
@@ -73,14 +73,14 @@
     <div class="w-container">
       <div class="w-layout-grid grid grid-2">
         <div class="shout-box grid-span-2">
-          <h1 class="shout">We help people find public records about police systems.<br></h1>
+          <h1 class="shout">We help people access public records about police systems.<br></h1>
           <p class="bottom-0">We're activists, researchers, journalists, municipal workers, and other people interested in transparent government.</p>
         </div>
         <div>
-          <h3>Request data</h3>
+          <h3>Access data</h3>
           <p>If you're looking for data, we can help! Our community has assembled 
             to help each other share public records.</p>
-          <a href="https://airtable.com/shrbFfWk6fjzGnNsk"><div class="button w-button">Request data</div></a>
+          <a href="https://airtable.com/shrbFfWk6fjzGnNsk"><div class="button w-button">Get help with data</div></a>
         </div>
         <div>
           <h3>Volunteer</h3>

--- a/index.html
+++ b/index.html
@@ -62,10 +62,10 @@
     </div>
     <nav role="navigation" class="nav-menu w-nav-menu">
       <a href="index.html" aria-current="page" class="nav-link w-nav-link w--current">Home</a>
-      <a href="about.html" class="nav-link w-nav-link">About</a>
+      <a href="data-sources.html" class="nav-link w-nav-link">Data Sources</a>
       <a href="contribute.html" class="nav-link w-nav-link">Contribute</a>
+      <a href="about.html" class="nav-link w-nav-link">About</a>
       <a href="https://docs.pdap.io/" class="nav-link w-nav-link">Docs</a>
-      <a href="https://newsletter.pdap.io" class="nav-link w-nav-link">Newsletter</a>
       <a href="jobs.html" class="nav-link w-nav-link">Jobs</a>
     </nav>
   </div>

--- a/jobs.html
+++ b/jobs.html
@@ -70,7 +70,7 @@
   <div class="footer wf-section">
     <div class="container w-container">
       <div class="footer-actions">
-        <a href="https://github.com/orgs/Police-Data-Accessibility-Project/projects/17" class="button button-footer w-button">GitHub</a>
+        <a href="https://github.com/orgs/Police-Data-Accessibility-Project" class="button button-footer w-button">GitHub</a>
         <a href="https://discord.gg/wMqex8nKZJ" class="button button-footer w-button">Discord</a>
         <a href="https://www.linkedin.com/company/pdap" class="button button-footer w-button">LinkedIn</a>
       </div>

--- a/jobs.html
+++ b/jobs.html
@@ -49,11 +49,11 @@
     </div>
     <nav role="navigation" class="nav-menu w-nav-menu">
       <a href="index.html" class="nav-link w-nav-link">Home</a>
-      <a href="about.html" aria-current="page" class="nav-link w-nav-link w--current">About</a>
+      <a href="data-sources.html" class="nav-link w-nav-link">Data Sources</a>
       <a href="contribute.html" class="nav-link w-nav-link">Contribute</a>
+      <a href="about.html" class="nav-link w-nav-link">About</a>
       <a href="https://docs.pdap.io/" class="nav-link w-nav-link">Docs</a>
-      <a href="https://newsletter.pdap.io" class="nav-link w-nav-link">Newsletter</a>
-      <a href="jobs.html" class="nav-link w-nav-link">Jobs</a>
+      <a href="jobs.html" aria-current="page" class="nav-link w-nav-link w--current">Jobs</a>
     </nav>
   </div>
   <div class="wf-section">

--- a/style-guide.html
+++ b/style-guide.html
@@ -70,7 +70,7 @@
   <div class="footer wf-section">
     <div class="container w-container">
       <div class="footer-actions">
-        <a href="https://github.com/orgs/Police-Data-Accessibility-Project/projects/17" class="button button-footer w-button">GitHub</a>
+        <a href="https://github.com/orgs/Police-Data-Accessibility-Project" class="button button-footer w-button">GitHub</a>
         <a href="https://discord.gg/wMqex8nKZJ" class="button button-footer w-button">Discord</a>
         <a href="https://www.linkedin.com/company/pdap" class="button button-footer w-button">LinkedIn</a>
       </div>


### PR DESCRIPTION
Adds an embedded view of the Data Sources database to the website. I also reshuffled the nav a bit to make room.

It's less nice on mobile, but still possible—Airtable did a decent job here.

<img width="1496" alt="Screen Shot 2023-04-26 at 12 18 41 PM" src="https://user-images.githubusercontent.com/30379833/234638923-59e21bac-3ee7-4a55-b82e-263b4c9b8ad4.png">
