### PR TITLE
refactor: update render of QuickSearchForm on HomeView

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
 				"@vitejs/plugin-vue-jsx": "^3.0.2",
 				"autoprefixer": "^10.4.16",
 				"npm-run-all2": "^6.0.6",
-				"pdap-design-system": "^2.1.5",
+				"pdap-design-system": "^2.1.8",
 				"postcss": "^8.4.32",
 				"tailwindcss": "^3.3.5",
 				"vite": "^4.4.9",
@@ -2837,9 +2837,9 @@
 			"dev": true
 		},
 		"node_modules/pdap-design-system": {
-			"version": "2.1.5",
-			"resolved": "https://registry.npmjs.org/pdap-design-system/-/pdap-design-system-2.1.5.tgz",
-			"integrity": "sha512-NiSAIcK92x/SphaYAG4DgWZPyJSVRKEpNgAHS3SFAYPEsegBXQKWID6HU7NFwNEXIBVXrDN7hrLhmI/irpPUuw==",
+			"version": "2.1.8",
+			"resolved": "https://registry.npmjs.org/pdap-design-system/-/pdap-design-system-2.1.8.tgz",
+			"integrity": "sha512-K3JGG95PR7Xc2LB3fdynUCuKS2UHqkHWGLi7qVaSqr8cECB29239WnIELJB8NzmtvZwMwaPBW9GhqsG0559cCw==",
 			"dev": true,
 			"dependencies": {
 				"@vuelidate/core": "^2.0.3",
@@ -3662,9 +3662,9 @@
 			}
 		},
 		"node_modules/vite": {
-			"version": "4.5.1",
-			"resolved": "https://registry.npmjs.org/vite/-/vite-4.5.1.tgz",
-			"integrity": "sha512-AXXFaAJ8yebyqzoNB9fu2pHoo/nWX+xZlaRwoeYUxEqBO+Zj4msE5G+BhGBll9lYEKv9Hfks52PAF2X7qDYXQA==",
+			"version": "4.5.2",
+			"resolved": "https://registry.npmjs.org/vite/-/vite-4.5.2.tgz",
+			"integrity": "sha512-tBCZBNSBbHQkaGyhGCDUGqeo2ph8Fstyp6FMSvTtsXeZSPpSMGlviAOav2hxVTqFcx8Hj/twtWKsMJXNY0xI8w==",
 			"dev": true,
 			"dependencies": {
 				"esbuild": "^0.18.10",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
 		"@vitejs/plugin-vue-jsx": "^3.0.2",
 		"autoprefixer": "^10.4.16",
 		"npm-run-all2": "^6.0.6",
-		"pdap-design-system": "^2.1.5",
+		"pdap-design-system": "^2.1.8",
 		"postcss": "^8.4.32",
 		"tailwindcss": "^3.3.5",
 		"vite": "^4.4.9",

--- a/src/views/HomeView.vue
+++ b/src/views/HomeView.vue
@@ -11,7 +11,7 @@
 			</p>
 		</GridItem>
 		<GridItem class="border-2 border-brand-gold p-4 md:p-6" :span-column="2">
-			<QuickSearchForm />
+			<QuickSearchForm :baseUrlForRedirect="baseUrlForRedirect" />
 		</GridItem>
 	</GridContainer>
 	<FlexContainer component="section">
@@ -137,6 +137,13 @@ export default {
     GridItem,
     QuickSearchForm,
     RouterLink
-},
+	},
+	data() {
+		return {
+			baseUrlForRedirect: import.meta.env.MODE === 'production' 
+			? 'https://data-sources.pdap.io' 
+			: 'https://data-sources.pdap.dev'
+		};
+	}
 };
 </script>


### PR DESCRIPTION
This will take care of #169 when merged to main.
Also: bumped `vite` to `4.5.1` to address a security vulnerability.

## To test
Check out PR, then locally:
1. Run `npm run build && npm run preview`
2. Search from home page.
3. You should be redirected to `https://data-sources.pdap.io/search....`
4. Kill the preview server.
5. Run `npm run build -- --mode development && npm run preview`
6. Repeat step 2
7. You should be redirected to `https://data-sources.pdap.dev/search....`

NOTE: As a part of this work, I updated the build command for `pdap.dev` in Digital Ocean to be `npm run build -- --mode development`. So we'll need to double check that this is all working correctly when deployed on merge to `dev` before going to `main` (although `pdap.io`'s build command remains unchanged, FWIW).