### PR TITLE
fix: replace FlexContainer, GridContainer, and GridItem

### DIFF
--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,13 +1,8 @@
-/** @type {import('tailwindcss').Config} */
-module.exports = {
-  content: [
-    "./index.html",
-    "./src/**/*.{vue,js,css}",
-  ],
-  /* Avoid customizing the tailwind config of this app, and modify the design system instead. */
-  theme: {
-    extend: {},
-  },
-  plugins: [],
-}
+import { tailwindConfig } from "pdap-design-system";
 
+/** @type {import('tailwindcss').Config} */
+export default {
+	...tailwindConfig,
+	content: ["index.html", "src/**/*.{vue,js,css}"],
+	plugins: [],
+};


### PR DESCRIPTION
fixes #164 

- Updates `tailwind.config.js` to use the tailwind config exported by design-system
- I realized it wasn't going to be a simple job to replace the containers and paused