### PR TITLE
add lead engineer to the website

### DIFF
--- a/src/views/AboutView.vue
+++ b/src/views/AboutView.vue
@@ -27,6 +27,9 @@
 				Our Executive Director is
 				<a href="https://www.linkedin.com/in/josh-chamberlain/">Josh Chamberlain</a>.
 			</p>
+			<p>
+				Our Lead Software Engineer is <a href="https://www.linkedin.com/in/maxachis/">Max Chis</a>.
+			</p>
 		</GridItem>
 		<GridItem component="FlexContainer" :span-column="1">
 			<h2>Funding</h2>


### PR DESCRIPTION
We have a new lead engineer! Staff are traditionally listed on the website.