### PR TITLE
refactor: swap <i> tags containing font awesome classes with font awesome's vue components

### DIFF
--- a/src/pages/community.vue
+++ b/src/pages/community.vue
@@ -76,7 +76,7 @@
     </div>
     <div class="col-span-full">
       <h2>
-        <i class="fa fa-code-fork" />
+        <FontAwesomeIcon :icon="faCodeFork" />
         Merged Pull Requests
       </h2>
       <p v-if="repoCount && mergeCount">
@@ -89,13 +89,13 @@
       <a
         href="https://github.com/orgs/Police-Data-Accessibility-Project/projects/25/views/1"
       >
-        <i class="fa fa-external-link" />
+      <FontAwesomeIcon :icon="faExternalLink" />
         Good first issues
       </a>
     </div>
     <div class="text-xl hyphens-auto" lang="en">
       <h3>
-        <i class="fa fa-map-o" aria-hidden="true" />
+        <FontAwesomeIcon :icon="faMap" aria-hidden="true" />
         Locate sources
       </h3>
       <p>
@@ -106,7 +106,7 @@
     </div>
     <div class="text-xl hyphens-auto" lang="en">
       <h3>
-        <i class="fa fa-eye-slash" />
+        <FontAwesomeIcon :icon="faEyeSlash" />
         Research
       </h3>
       <p>
@@ -117,7 +117,7 @@
     </div>
     <div class="text-xl hyphens-auto" lang="en">
       <h3>
-        <i class="fa fa-file-code-o" />
+        <FontAwesomeIcon :icon="faFileCode" /> Code
         Code
       </h3>
       <p>
@@ -148,6 +148,14 @@
 <script setup>
 import { ref, onMounted } from "vue";
 import axios from "axios";
+import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
+import {
+	faCodeFork,
+	faExternalLink,
+	faMap,
+	faEyeSlash,
+	faFileCode
+} from "@fortawesome/free-solid-svg-icons";
 
 const repoCount = ref(0);
 const mergeCount = ref(0);

--- a/src/pages/jobs.vue
+++ b/src/pages/jobs.vue
@@ -49,7 +49,7 @@
             Software development opportunities
           </h2>
           <h4>
-            <i class="fa fa-info-circle" />
+            <FontAwesomeIcon :icon="faInfoCircle" />
             Remote, temporary
           </h4>
           <p>
@@ -110,3 +110,10 @@
     </div>
   </section>
 </template>
+
+<script setup>
+import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
+import {
+	faInfoCircle
+} from "@fortawesome/free-solid-svg-icons";
+</script>


### PR DESCRIPTION
Changes the tags containing the font awesome classes to vue components in 2 files.
src/
├── pages/
│ ├── community.vue
│ ├── jobs.vue

Will addr. #194 when merged to `main`

Before
![Screenshot_08-Jan_11-02-37_19462](https://github.com/user-attachments/assets/ba0e390d-fc21-4758-b444-4bf260f48980)
![Screenshot_08-Jan_11-03-30_1137](https://github.com/user-attachments/assets/7a7a74fc-b873-45ee-9274-b4c5514acfd0)

After
![Screenshot_08-Jan_11-02-53_30816](https://github.com/user-attachments/assets/232d2828-7f50-405a-81fd-ad02f265624b)
![Screenshot_08-Jan_11-03-41_15055](https://github.com/user-attachments/assets/5889bc21-bc78-4c44-84ba-fec5aacae391)
