### PR TITLE
visual tweaks

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ VITE_API_URL=https://data-sources-v2.pdap.dev/api # Or 'https://data-sources-v2.
 VITE_V2_FEATURE_ENHANCED_SEARCH=enabled
 VITE_V2_FEATURE_AUTHENTICATE=enabled
 VITE_V2_FEATURE_CREATE_RECORDS=enabled
+VITE_V2_FEATURE_SHOW_REQUESTS=enabled
 ```
 
 _Note: You can also override these vars when starting the dev server if you'd rather not update an env file every time you need a different value, by passing the value to the command line before running the server i.e:_ `VITE_API_URL=localhost:5000 npm run dev`

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "dotenv": "^16.4.7",
         "jwt-decode": "^4.0.0",
         "lodash": "^4.17.21",
-        "pdap-design-system": "^3.1.0-beta.37",
+        "pdap-design-system": "^3.1.0-beta.38",
         "pinia": "^2.1.7",
         "pinia-plugin-persistedstate": "^3.2.1",
         "vue": "^3.4.19",
@@ -4597,9 +4597,13 @@
       }
     },
     "node_modules/pdap-design-system": {
-      "version": "3.1.0-beta.37",
-      "resolved": "https://registry.npmjs.org/pdap-design-system/-/pdap-design-system-3.1.0-beta.37.tgz",
-      "integrity": "sha512-sX/dx+Y8Wv1MY3fRbRRJPDsZujgV4BE7s5Gn8/e3VJsa3jrlzQfcFdjt+GnHUu6lNmas8Zaygy4ElE4nL5cs5Q==",
+      "version": "3.1.0-beta.38",
+      "resolved": "https://registry.npmjs.org/pdap-design-system/-/pdap-design-system-3.1.0-beta.38.tgz",
+      "integrity": "sha512-gGYxSjopqWCnFOA1H3aqqTlwsAPQHghuH58oGLGArdJXMLMvdYalw+p/r7ehOCoACTCq8sFcBWc8jEjqkzp1Dw==",
+      "license": "ISC",
+      "workspaces": [
+        "eslint-config"
+      ],
       "dependencies": {
         "@fortawesome/fontawesome-svg-core": "^6.6.0",
         "@fortawesome/free-brands-svg-icons": "^6.6.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "dotenv": "^16.4.7",
         "jwt-decode": "^4.0.0",
         "lodash": "^4.17.21",
-        "pdap-design-system": "^3.1.0-beta.38",
+        "pdap-design-system": "^3.1.0-beta.40",
         "pinia": "^2.1.7",
         "pinia-plugin-persistedstate": "^3.2.1",
         "vue": "^3.4.19",
@@ -4597,9 +4597,9 @@
       }
     },
     "node_modules/pdap-design-system": {
-      "version": "3.1.0-beta.38",
-      "resolved": "https://registry.npmjs.org/pdap-design-system/-/pdap-design-system-3.1.0-beta.38.tgz",
-      "integrity": "sha512-gGYxSjopqWCnFOA1H3aqqTlwsAPQHghuH58oGLGArdJXMLMvdYalw+p/r7ehOCoACTCq8sFcBWc8jEjqkzp1Dw==",
+      "version": "3.1.0-beta.40",
+      "resolved": "https://registry.npmjs.org/pdap-design-system/-/pdap-design-system-3.1.0-beta.40.tgz",
+      "integrity": "sha512-+rRtfXt/98UrcreutWO4iqHB0xjS0cuUD7mnHs3zrHZKMWp9g7RotrdeCTBPsC/iihFli3vdv9JXSnJ4qof6pw==",
       "license": "ISC",
       "workspaces": [
         "eslint-config"

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "dotenv": "^16.4.7",
     "jwt-decode": "^4.0.0",
     "lodash": "^4.17.21",
-    "pdap-design-system": "^3.1.0-beta.38",
+    "pdap-design-system": "^3.1.0-beta.40",
     "pinia": "^2.1.7",
     "pinia-plugin-persistedstate": "^3.2.1",
     "vue": "^3.4.19",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "dotenv": "^16.4.7",
     "jwt-decode": "^4.0.0",
     "lodash": "^4.17.21",
-    "pdap-design-system": "^3.1.0-beta.37",
+    "pdap-design-system": "^3.1.0-beta.38",
     "pinia": "^2.1.7",
     "pinia-plugin-persistedstate": "^3.2.1",
     "vue": "^3.4.19",

--- a/src/components/SearchForm.vue
+++ b/src/components/SearchForm.vue
@@ -1,6 +1,6 @@
 <template>
   <div
-    class="col-span-1 flex flex-col gap-6 mt-8 @md:col-span-2 @lg:col-span-3 @md:flex-row @md:gap-0">
+    class="col-span-1 flex flex-col gap-4 mt-8 @md:col-span-2 @lg:col-span-3 @md:flex-row @md:gap-0">
     <TypeaheadInput
       :id="TYPEAHEAD_ID"
       ref="typeaheadRef"
@@ -37,7 +37,7 @@
   <FormV2
     id="pdap-data-sources-search"
     ref="formRef"
-    class="grid grid-cols-1 auto-rows-auto max-w-full gap:0 @md:gap-4 @md:grid-cols-2 @lg:grid-cols-3 gap-0"
+    class="grid grid-cols-1 auto-rows-auto max-w-full gap-0.5 @md:gap-1 @md:grid-cols-2 @lg:grid-cols-3"
     @change="onChange"
     @submit="submit">
     <InputCheckbox

--- a/src/components/TypeaheadInput.vue
+++ b/src/components/TypeaheadInput.vue
@@ -240,7 +240,7 @@ defineExpose({
 
 .pdap-typeahead-input,
 .pdap-typeahead-list {
-  @apply bg-neutral-50 border-2 border-neutral-500 border-solid p-2 text-neutral-950;
+  @apply bg-neutral-50 border-2 border-goldneutral-500 border-solid p-2 text-neutral-950;
 }
 
 .pdap-typeahead-input::placeholder {

--- a/src/main.css
+++ b/src/main.css
@@ -17,7 +17,7 @@
   }
 
   .pill {
-    @apply text-neutral-800 border-solid border border-goldneutral-300 rounded-full px-2 bg-goldneutral-100 text-xs sm:text-sm [&>*]:md:text-med [&>*]:lg:text-lg p-1 overflow-hidden;
+    @apply text-goldneutral-950 border-solid border border-goldneutral-300 rounded-full px-2 bg-goldneutral-100 text-xs sm:text-sm [&>*]:md:text-med [&>*]:lg:text-lg p-1 overflow-hidden;
   }
 
   .like-h4 {

--- a/src/main.css
+++ b/src/main.css
@@ -17,7 +17,7 @@
   }
 
   .pill {
-    @apply text-goldneutral-950 border-solid border border-goldneutral-300 rounded-full px-2 bg-goldneutral-100 text-xs sm:text-sm [&>*]:md:text-med [&>*]:lg:text-lg p-1 overflow-hidden;
+    @apply text-wineneutral-950 border-solid border border-wineneutral-300 rounded-full px-3 py-1.5 bg-wineneutral-100 text-xs sm:text-sm [&>*]:md:text-med [&>*]:lg:text-lg overflow-hidden;
   }
 
   .like-h4 {

--- a/src/main.css
+++ b/src/main.css
@@ -17,7 +17,7 @@
   }
 
   .pill {
-    @apply text-neutral-800 border-solid border-[1px] border-neutral-500 rounded-xl px-2 bg-neutral-200 text-xs sm:text-sm [&>*]:md:text-med [&>*]:lg:text-lg p-1 overflow-hidden;
+    @apply text-neutral-800 border-solid border border-goldneutral-300 rounded-full px-2 bg-goldneutral-100 text-xs sm:text-sm [&>*]:md:text-med [&>*]:lg:text-lg p-1 overflow-hidden;
   }
 
   .like-h4 {

--- a/src/pages/about.vue
+++ b/src/pages/about.vue
@@ -1,5 +1,5 @@
 <template>
-  <main class="pdap-grid-container px-4 md:px-8 mb-24">
+  <main class="pdap-grid-container mb-24">
     <section class="col-span-full pdap-flex-container">
       <h1 class="col-span-full">About</h1>
       <p>

--- a/src/pages/data-request/create.vue
+++ b/src/pages/data-request/create.vue
@@ -7,7 +7,7 @@
 </route>
 
 <template>
-  <main class="overflow-x-hidden max-w-[1080px] px-6 md:px-10 mx-auto">
+  <main class="overflow-x-hidden max-w-[1080px] mx-auto">
     <h1>New request</h1>
 
     <FormV2

--- a/src/pages/data-source/[id].vue
+++ b/src/pages/data-source/[id].vue
@@ -1,11 +1,12 @@
 <template>
-  <main ref="mainRef" class="min-h-[75%] relative">
+  <main ref="mainRef" class="min-h-[75%] pdap-flex-container relative">
     <!-- NAV to prev/next data source -->
     <PrevNextNav
       :search-ids="searchStore.mostRecentSearchIds"
       :previous-index="previousIdIndex"
       :next-index="nextIdIndex"
-      :set-nav-is="(val) => (navIs = val)" />
+      :set-nav-is="(val) => (navIs = val)"
+      class="text-xl font-semibold" />
 
     <transition mode="out-in" :name="navIs">
       <div
@@ -40,18 +41,44 @@
                 <RecordTypeIcon :record-type="dataSource.record_type_name" />
                 {{ dataSource.record_type_name }}
               </p>
+              <p
+                v-for="agency in dataSource.agencies"
+                :key="agency.jurisdiction_type"
+                class="pill">
+                Jurisdiction: {{ agency.jurisdiction_type }}
+              </p>
               <template v-if="Array.isArray(dataSource.tags)">
                 <p v-for="tag in dataSource.tags" :key="tag" class="pill w-max">
                   {{ tag }}
                 </p>
               </template>
             </div>
+            <!-- Description -->
+            <div v-if="dataSource.description" class="relative w-full mt-4">
+              <h4>
+                Description
+              </h4>
+              <p
+                ref="descriptionRef"
+                class="description"
+                :class="{
+                  'truncate-2': !isDescriptionExpanded
+                }">
+                {{ dataSource.description }}
+              </p>
+              <Button
+                v-if="showExpandDescriptionButton"
+                intent="tertiary"
+                @click="isDescriptionExpanded = !isDescriptionExpanded">
+                {{ isDescriptionExpanded ? 'See less' : 'See more' }}
+              </Button>
+            </div>
           </hgroup>
 
           <!-- Agency data -->
-          <div class="flex-[0_0_100%] flex flex-col gap-2 w-full">
-            <div ref="agenciesRef" class="agency-row-container">
-              <div class="agency-row">
+          <div class="flex-[0_0_100%] flex flex-col w-full">
+            <div ref="agenciesRef" class="w-full self-start justify-self-start mb-4">
+              <div class="inline-flex flex-wrap gap-8 [&>div]:w-max">
                 <div>
                   <h4 class="m-0">Agency</h4>
                   <p
@@ -81,15 +108,6 @@
                     {{ agency.agency_type }}
                   </p>
                 </div>
-                <div>
-                  <h4 class="m-0">Jurisdiction Type</h4>
-                  <p
-                    v-for="agency in dataSource.agencies"
-                    :key="agency.jurisdiction_type"
-                    class="capitalize">
-                    {{ agency.jurisdiction_type }}
-                  </p>
-                </div>
               </div>
             </div>
             <a
@@ -100,23 +118,6 @@
               Visit Data Source
               <FontAwesomeIcon :icon="faLink" />
             </a>
-          </div>
-
-          <div v-if="dataSource.description" class="description-container">
-            <p
-              ref="descriptionRef"
-              class="description"
-              :class="{
-                'truncate-2': !isDescriptionExpanded
-              }">
-              {{ dataSource.description }}
-            </p>
-            <Button
-              v-if="showExpandDescriptionButton"
-              intent="tertiary"
-              @click="isDescriptionExpanded = !isDescriptionExpanded">
-              {{ isDescriptionExpanded ? 'See less' : 'See more' }}
-            </Button>
           </div>
 
           <!-- Sections -->
@@ -293,17 +294,13 @@ function formatResult(record, item) {
 
 <style scoped>
 .section {
-  @apply w-full flex flex-col gap-2 max-w-full md:max-w-[50%] border-solid border-2 border-neutral-300 p-4;
+  @apply w-full flex flex-col gap-2 max-w-full md:max-w-[50%] border-solid border-2 border-neutral-300 p-4 text-lg;
   flex: 1 1 40%;
 }
 
 hgroup {
   @apply mt-4 self-start;
   flex: 0 0 100%;
-}
-
-.description-container {
-  @apply relative w-full mt-4;
 }
 
 .description {
@@ -317,14 +314,6 @@ hgroup {
 
 .pdap-button-tertiary {
   @apply text-brand-gold-600 p-1;
-}
-
-.agency-row {
-  @apply inline-flex gap-8 [&>div]:w-max;
-}
-
-.agency-row-container {
-  @apply w-full overflow-x-scroll self-start justify-self-start my-4;
 }
 
 .increment-enter-active,

--- a/src/pages/data-source/[id].vue
+++ b/src/pages/data-source/[id].vue
@@ -55,9 +55,7 @@
             </div>
             <!-- Description -->
             <div v-if="dataSource.description" class="relative w-full mt-4">
-              <h4>
-                Description
-              </h4>
+              <h4>Description</h4>
               <p
                 ref="descriptionRef"
                 class="description"
@@ -77,7 +75,9 @@
 
           <!-- Agency data -->
           <div class="flex-[0_0_100%] flex flex-col w-full">
-            <div ref="agenciesRef" class="w-full self-start justify-self-start mb-4">
+            <div
+              ref="agenciesRef"
+              class="w-full self-start justify-self-start mb-4">
               <div class="inline-flex flex-wrap gap-8 [&>div]:w-max">
                 <div>
                   <h4 class="m-0">Agency</h4>

--- a/src/pages/data-source/_util.js
+++ b/src/pages/data-source/_util.js
@@ -74,7 +74,7 @@ export const DATA_SOURCE_UI_SHAPE = [
         key: 'record_formats',
         component: 'span',
         classNames:
-          'mt-1 py-[.125rem] px-3 rounded-full bg-slate-200 dark:bg-slate-600 w-fit small text-neutral-800 border-solid border-[1px] border-neutral-500 rounded-xl px-2 bg-neutral-200 text-xs sm:text-sm [&>*]:md:text-med [&>*]:lg:text-lg p-1 overflow-hidden'
+          'pill w-fit border-wineneutral-500 text-xs sm:text-sm [&>*]:md:text-med [&>*]:lg:text-lg overflow-hidden'
       },
       { title: 'Detail Level', key: 'detail_level' },
       { title: 'Size', key: 'size' },

--- a/src/pages/data-source/create.vue
+++ b/src/pages/data-source/create.vue
@@ -7,7 +7,7 @@
 </route>
 
 <template>
-  <main class="overflow-x-hidden max-w-[1080px] px-6 md:px-10 mx-auto">
+  <main class="overflow-x-hidden max-w-[1080px] mx-auto">
     <!-- TODO: this component is massive. Let's break it up into components and move the constants and utils to separate files.
 			------ Also: the additional properties section is probably meaty enough that we want an async import.
 			------ Maybe even a separate sub-route? At `.data-source/create/additional` ? 

--- a/src/pages/index.vue
+++ b/src/pages/index.vue
@@ -99,14 +99,14 @@
           The problem we address is the inaccessibility of data about the
           systems with the
           <strong>greatest impact on our lives.</strong>
-          Records which should be public are often disorganized, scattered across
-          obscure municipal websites, kept behind tedious request processes, or
-          not published at all.
+          Records which should be public are often disorganized, scattered
+          across obscure municipal websites, kept behind tedious request
+          processes, or not published at all.
         </p>
         <p>
           <strong>We envision a future</strong>
-          where every community in the United States can access public data 
-          to evaluate local police systems and other crisis response programs.
+          where every community in the United States can access public data to
+          evaluate local police systems and other crisis response programs.
         </p>
         <p>
           All of our programs exist to help people answer questions with data.
@@ -131,8 +131,11 @@
       </p>
       <p>
         Our documentation at
-        <strong><a href="https://docs.pdap.io">docs.pdap.io</a>
-        is the starting point</strong> for using our tools to do things with data.
+        <strong>
+          <a href="https://docs.pdap.io">docs.pdap.io</a>
+          is the starting point
+        </strong>
+        for using our tools to do things with data.
       </p>
       <h2>
         <FontAwesomeIcon

--- a/src/pages/index.vue
+++ b/src/pages/index.vue
@@ -5,7 +5,7 @@
 </route>
 
 <template>
-  <main class="p-6 py-10 mb-24 pdap-grid-container @container w-full">
+  <main class="mb-24 pdap-grid-container @container w-full">
     <section class="col-span-full">
       <h1>Explore data about police systems</h1>
       <SearchForm />

--- a/src/pages/search/_components/SearchResults.vue
+++ b/src/pages/search/_components/SearchResults.vue
@@ -30,7 +30,7 @@
               v-for="agency in Object.keys(results[locale].sourcesByAgency)"
               :key="agency + 'results'">
               <div class="agency-heading-row">
-                <h5>{{ agency }}</h5>
+                <h5 class="font-semibold">{{ agency }}</h5>
                 <span class="pill">{{ locale }}</span>
               </div>
 
@@ -45,7 +45,7 @@
                   <h6>
                     {{ source.data_source_name }}
                   </h6>
-                  <span class="pill flex items-center gap-2 w-max">
+                  <span class="pill flex items-center mt-1 gap-2 w-max">
                     <RecordTypeIcon :record-type="source.record_type" />
                     {{ source.record_type }}
                   </span>
@@ -61,19 +61,13 @@
                   {{ source.description ?? '—' }}
                 </p>
 
-                <!-- Formats and links to data source view and data source url -->
-                <div :class="getClassNameFromHeadingType(HEADING_TITLES[3])">
-                  <span
-                    v-for="format of source.record_formats"
-                    :key="source.data_source_name + format"
-                    class="pill format">
-                    {{ format }}
-                  </span>
-                </div>
+                <!-- Links to data source view and data source url -->
                 <div class="links">
-                  <FontAwesomeIcon
-                    class="hidden lg:inline top-1 text-brand-gold-600 group-hover:text-brand-gold-300"
-                    :icon="faInfo" />
+                  <span
+                    class="hidden lg:inline top-1 text-brand-gold-600 group-hover:text-brand-gold-300">
+                    <FontAwesomeIcon :icon="faInfoCircle" />
+                    More
+                  </span>
                   <a
                     :href="source.source_url"
                     target="_blank"
@@ -81,7 +75,7 @@
                     @keydown.stop.enter=""
                     @click.stop="">
                     <FontAwesomeIcon :icon="faLink" />
-                    source
+                    Visit
                   </a>
                 </div>
               </RouterLink>
@@ -96,7 +90,7 @@
 <script setup>
 import { ALL_LOCATION_TYPES } from '@/util/constants';
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
-import { faInfo, faLink } from '@fortawesome/free-solid-svg-icons';
+import { faInfoCircle, faLink } from '@fortawesome/free-solid-svg-icons';
 import { RecordTypeIcon, Spinner } from 'pdap-design-system';
 import { useRoute } from 'vue-router';
 import { ref, watchEffect } from 'vue';
@@ -105,11 +99,10 @@ const route = useRoute();
 
 // constants
 const HEADING_TITLES = [
-  'agency, name, record type',
+  'name, record type',
   'time range',
   'description',
-  'formats',
-  'details'
+  'actions'
 ];
 
 const { results, isLoading } = defineProps({
@@ -148,7 +141,7 @@ function getYearRange(start, end) {
 }
 
 function getClassNameFromHeadingType(heading) {
-  if (heading === 'details') return 'links';
+  if (heading === 'actions') return 'links';
   return heading.replaceAll(',', '').split(' ').join('-');
 }
 </script>
@@ -169,25 +162,21 @@ h6 {
 .heading-titles,
 .agency-row {
   /* Tailwind is a pain for complex grids, so using standard CSS */
-  grid-template-columns: 6fr 2fr 1fr;
-  grid-template-areas: 'name name name' 'range formats formats';
+  grid-template-columns: 6fr 1fr 2fr 1fr;
+  grid-template-areas: 'name range description links';
   grid-template-rows: repeat(2, auto);
 }
 
 .heading-titles {
-  @apply w-full items-center grid gap-1 gap-y-3 [&>*]:text-[.7rem] [&>*]:md:text-med [&>*]:lg:text-lg p-2 border-solid border-neutral-300 border-2 lg:border-none;
-}
-
-h4.formats {
-  @apply break-all overflow-hidden;
+  @apply w-full items-center grid gap-1 gap-y-3 [&>*]:text-[.7rem] [&>*]:md:text-med [&>*]:lg:text-lg border-solid border-neutral-300 border-2 lg:border-none;
 }
 
 .agency-heading-row {
-  @apply flex items-center sticky top-0 mb-4 justify-between gap-4 bg-neutral-100 p-2 rounded-sm [&>*]:text-xs [&>*]:md:text-med [&>*]:lg:text-lg border-solid border-neutral-300 border-2 z-10;
+  @apply flex items-center sticky top-0 mb-2 justify-between gap-4 bg-wineneutral-100 p-2 [&>*]:text-xs [&>*]:md:text-med [&>*]:lg:text-lg border-solid border-wineneutral-300 border-2 z-10;
 }
 
 .agency-row {
-  @apply grid gap-4 mb-4 p-2 h-auto lg:h-[91px] border-solid border-neutral-300 border-2 rounded-sm [&>*]:text-sm [&>*]:md:text-med [&>*]:lg:text-lg text-neutral-950 hover:bg-neutral-100;
+  @apply grid gap-4 mb-2 p-2 h-auto border-solid border-wineneutral-300 border [&>*]:text-sm [&>*]:md:text-med [&>*]:lg:text-lg text-neutral-950 hover:bg-goldneutral-100;
 }
 
 .agency-row:focus,
@@ -204,8 +193,8 @@ h4.formats {
   .heading-titles,
   .agency-row {
     /* Tailwind is a pain for complex grids, so using standard CSS */
-    grid-template-columns: 5fr 2fr 3fr;
-    grid-template-areas: 'name name name' 'range formats links';
+    grid-template-columns: 5fr 2fr 1fr 1fr;
+    grid-template-areas: 'name range description links';
   }
 }
 
@@ -214,9 +203,9 @@ h4.formats {
   .agency-row {
     @apply gap-4;
 
-    grid-template-columns: 320px 125px 1fr 128px 115px;
+    grid-template-columns: 320px 125px 1fr 115px;
     grid-template-rows: repeat(1, auto);
-    grid-template-areas: 'name range description formats links';
+    grid-template-areas: 'name range description links';
   }
 }
 
@@ -256,21 +245,8 @@ h4.links {
 }
 
 div.links {
-  @apply hidden md:flex h-auto gap-2;
+  @apply hidden md:flex md:flex-col items-end justify-start h-auto gap-2;
 
   grid-area: links;
-}
-
-.formats {
-  @apply flex flex-wrap gap-2 justify-start max-w-32 h-max;
-  grid-area: formats;
-}
-
-div.formats {
-  @apply overflow-hidden h-full;
-}
-
-.format {
-  @apply p-0 px-1 text-med inline-block w-min max-w-[8ch] h-min whitespace-nowrap text-ellipsis line-clamp-1;
 }
 </style>

--- a/src/pages/search/_components/SearchResults.vue
+++ b/src/pages/search/_components/SearchResults.vue
@@ -245,7 +245,7 @@ h4.links {
 }
 
 div.links {
-  @apply hidden md:flex md:flex-col items-end justify-start h-auto gap-2;
+  @apply hidden md:flex md:flex-col items-end justify-start h-auto gap-1;
 
   grid-area: links;
 }

--- a/src/pages/search/_components/SearchResults.vue
+++ b/src/pages/search/_components/SearchResults.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="flex flex-col w-full gap-5">
+  <div class="flex flex-col w-full mb-1">
     <div class="heading-titles">
       <h4
         v-for="title of HEADING_TITLES"
@@ -170,7 +170,7 @@ h6 {
 }
 
 .heading-titles {
-  @apply w-full items-center grid gap-1 gap-y-3 [&>*]:text-[.7rem] [&>*]:md:text-med [&>*]:lg:text-lg border-solid border-neutral-300 border-2 lg:border-none;
+  @apply w-full items-center grid gap-1 gap-y-3 [&>*]:text-[.7rem] [&>*]:md:text-med [&>*]:lg:text-lg;
 }
 
 .agency-heading-row {

--- a/src/pages/search/_components/SearchResults.vue
+++ b/src/pages/search/_components/SearchResults.vue
@@ -46,7 +46,9 @@
                     {{ source.data_source_name }}
                   </h6>
                   <span class="pill flex items-center mt-1 gap-2 w-max">
-                    <RecordTypeIcon :record-type="source.record_type" />
+                    <RecordTypeIcon
+                      :record-type="source.record_type"
+                      class="text-brand-wine-500" />
                     {{ source.record_type }}
                   </span>
                 </div>
@@ -62,7 +64,7 @@
                 </p>
 
                 <!-- Links to data source view and data source url -->
-                <div class="links">
+                <div class="links text-lg">
                   <span
                     class="hidden lg:inline top-1 text-brand-gold-600 group-hover:text-brand-gold-300">
                     <FontAwesomeIcon :icon="faInfoCircle" />
@@ -172,21 +174,17 @@ h6 {
 }
 
 .agency-heading-row {
-  @apply flex items-center sticky top-0 mb-2 justify-between gap-4 bg-wineneutral-100 p-2 [&>*]:text-xs [&>*]:md:text-med [&>*]:lg:text-lg border-solid border-wineneutral-300 border-2 z-10;
+  @apply flex items-center sticky top-0 mb-2 gap-4 bg-wineneutral-100 p-2 text-xs md:text-med lg:text-lg border-solid border-wineneutral-300 border-2 z-10;
 }
 
 .agency-row {
-  @apply grid gap-4 mb-2 p-2 h-auto border-solid border-wineneutral-300 border [&>*]:text-sm [&>*]:md:text-med [&>*]:lg:text-lg text-neutral-950 hover:bg-goldneutral-100;
+  @apply grid gap-4 mb-2 p-2 h-auto border-solid border-wineneutral-300 border text-sm md:text-med lg:text-lg text-neutral-950 hover:bg-goldneutral-100;
 }
 
 .agency-row:focus,
 .agency-row:focus-visible,
 .agency-row:focus-within {
   @apply hover:brightness-85;
-}
-
-.agency-row * {
-  @apply [&>*]:text-sm [&>*]:md:text-med [&>*]:lg:text-lg;
 }
 
 @media (width >= 768px) {

--- a/src/pages/search/results.vue
+++ b/src/pages/search/results.vue
@@ -56,12 +56,12 @@
         <nav
           v-if="!error"
           class="flex gap-2 mb-4 [&>*]:text-[.72rem] [&>*]:xs:text-med [&>*]:sm:text-lg sm:gap-4 md:col-start-1 md:col-span-1 md:row-start-2 md:row-span-2 justify-baseline mt-2">
-          <span class="text-neutral-500">Jump to:</span>
+          <span class="font-semibold text-wineneutral-700">Jurisdiction level:</span>
           <RouterLink
             v-for="locale in ALL_LOCATION_TYPES"
             :key="`${locale} anchor`"
             :class="{
-              'text-neutral-500 pointer-events-none cursor-auto':
+              'text-goldneutral-500 pointer-events-none cursor-auto border-none':
                 !searchData?.results?.[locale]?.count
             }"
             class="capitalize"

--- a/src/pages/search/results.vue
+++ b/src/pages/search/results.vue
@@ -92,11 +92,12 @@
           <LoadingSpinner />
         </template>
       </Suspense>
-
-      <h2 v-if="searchData" class="like-h4">
-        Data requested about {{ getFullLocationText(searchData.params) }}
-      </h2>
-      <Requests :requests="requestData" :error="!!requestsError" />
+      <div v-if="getIsV2FeatureEnabled('SHOW_REQUESTS')">
+        <h2 v-if="searchData" class="like-h4">
+          Data requested about {{ getFullLocationText(searchData.params) }}
+        </h2>
+        <Requests :requests="requestData" :error="!!requestsError" />
+      </div>
     </section>
 
     <!-- Aside for handling filtering and saved searches -->

--- a/src/pages/search/results.vue
+++ b/src/pages/search/results.vue
@@ -56,7 +56,9 @@
         <nav
           v-if="!error"
           class="flex gap-2 mb-4 [&>*]:text-[.72rem] [&>*]:xs:text-med [&>*]:sm:text-lg sm:gap-4 md:col-start-1 md:col-span-1 md:row-start-2 md:row-span-2 justify-baseline mt-2">
-          <span class="font-semibold text-wineneutral-700">Jurisdiction level:</span>
+          <span class="font-semibold text-wineneutral-700">
+            Jurisdiction level:
+          </span>
           <RouterLink
             v-for="locale in ALL_LOCATION_TYPES"
             :key="`${locale} anchor`"

--- a/src/pages/search/results.vue
+++ b/src/pages/search/results.vue
@@ -56,17 +56,17 @@
         <nav
           v-if="!error"
           class="flex gap-2 mb-4 [&>*]:text-[.72rem] [&>*]:xs:text-med [&>*]:sm:text-lg sm:gap-4 md:col-start-1 md:col-span-1 md:row-start-2 md:row-span-2 justify-baseline mt-2">
-          <span class="font-semibold text-wineneutral-700">
+          <span class="font-semibold text-neutral-600 dark:text-neutral-300">
             Jurisdiction level:
           </span>
           <RouterLink
             v-for="locale in ALL_LOCATION_TYPES"
             :key="`${locale} anchor`"
             :class="{
-              'text-goldneutral-500 pointer-events-none cursor-auto border-none':
+              'text-goldneutral-500 pointer-events-none cursor-auto':
                 !searchData?.results?.[locale]?.count
             }"
-            class="capitalize"
+            class="capitalize border-none"
             :to="{ ...route, hash: `#${locale}` }"
             replace
             @click="

--- a/src/pages/search/results.vue
+++ b/src/pages/search/results.vue
@@ -5,12 +5,12 @@
     <section class="w-full h-full">
       <div
         class="grid grid-cols-1 md:grid-cols-[1fr,auto] md:grid-rows-[repeat(3,35px)]">
-        <h1 class="like-h4 mb-4">
-          Results
+        <h1 class="text-3xl mb-4">
+          Data
           {{
             searchData &&
             !isLoading &&
-            'for ' + getMinimalLocationText(searchData.params)
+            'about ' + getFullLocationText(searchData.params)
           }}
         </h1>
 
@@ -94,7 +94,7 @@
       </Suspense>
 
       <h2 v-if="searchData" class="like-h4">
-        Data requests for {{ getFullLocationText(searchData.params) }}
+        Data requested about {{ getFullLocationText(searchData.params) }}
       </h2>
       <Requests :requests="requestData" :error="!!requestsError" />
     </section>

--- a/src/pages/search/results.vue
+++ b/src/pages/search/results.vue
@@ -1,6 +1,6 @@
 <template>
   <main
-    class="grid grid-cols-1 grid-rows-[auto_1fr] xl:grid-cols-[1fr_340px] gap-4 xl:gap-x-8 max-w-[1800px] mx-auto">
+    class="grid grid-cols-1 grid-rows-[auto_1fr] xl:grid-cols-[1fr_340px] gap-4 max-w-[1800px] mx-auto">
     <!-- Search results -->
     <section class="w-full h-full">
       <div
@@ -57,7 +57,7 @@
           v-if="!error"
           class="flex gap-2 mb-4 [&>*]:text-[.72rem] [&>*]:xs:text-med [&>*]:sm:text-lg sm:gap-4 md:col-start-1 md:col-span-1 md:row-start-2 md:row-span-2 justify-baseline mt-2">
           <span class="font-semibold text-neutral-600 dark:text-neutral-300">
-            Jurisdiction level:
+            Geographic level:
           </span>
           <RouterLink
             v-for="locale in ALL_LOCATION_TYPES"

--- a/src/util/constants.js
+++ b/src/util/constants.js
@@ -8,10 +8,6 @@ export const NAV_LINKS = [
     text: 'Data'
   },
   {
-    href: 'https://docs.pdap.io/activities/publish-data',
-    text: 'Publish data'
-  },
-  {
     path: '/about',
     text: 'About'
   },
@@ -45,6 +41,11 @@ export const FOOTER_LINKS = [
     href: 'https://docs.pdap.io/',
     text: 'Docs',
     icon: FOOTER_LINK_ICONS.DOCS
+  },
+  {
+    href: 'https://docs.pdap.io/activities/publish-data',
+    text: 'Publish data',
+    icon: FOOTER_LINK_ICONS.PUBLISH
   },
   {
     href: 'mailto:contact@pdap.io',

--- a/src/util/featureFlagV2.js
+++ b/src/util/featureFlagV2.js
@@ -1,7 +1,7 @@
 /**
  * Gets enabled / disabled status for features.
  *
- * @param {'ENHANCED_SEARCH' | 'AUTHENTICATE' | 'CREATE_RECORDS'} featureName Name of V2 feature to check
+ * @param {'ENHANCED_SEARCH' | 'AUTHENTICATE' | 'CREATE_RECORDS' | 'SHOW_REQUESTS'} featureName Name of V2 feature to check
  * @returns {boolean} Whether the feature is enabled or not
  */
 export function getIsV2FeatureEnabled(featureName) {


### PR DESCRIPTION
- fixes https://github.com/Police-Data-Accessibility-Project/design-system/issues/123
- pairs with https://github.com/Police-Data-Accessibility-Project/design-system/pull/132

## Contains
- visually tunes search results (spacing, colors)
- visually tunes data source detail
- `formats available` removed from rows
- moves some single-use classes to in-context tailwind styles
- removes padding overrides for `main` (set from pdap-design-system)

## Acceptance criteria

- run `npm i && npm run dev`
- ensure things look good
