### PR TITLE
fix: home page misaligned on safari

### DIFF
--- a/src/pages/index.vue
+++ b/src/pages/index.vue
@@ -5,7 +5,7 @@
 </route>
 
 <template>
-  <main class="mb-24 pdap-grid-container @container w-full">
+  <main class="mb-24 grid-cols-3 max-w-5xl mx-auto @container w-full">
     <section class="col-span-full">
       <h1>Explore data about police systems</h1>
       <SearchForm />

--- a/src/pages/index.vue
+++ b/src/pages/index.vue
@@ -5,7 +5,7 @@
 </route>
 
 <template>
-  <main class="mb-24 grid-cols-3 max-w-5xl mx-auto @container w-full">
+  <main class="mb-24 grid grid-cols-3 max-w-5xl mx-auto @container w-full">
     <section class="col-span-full">
       <h1>Explore data about police systems</h1>
       <SearchForm />


### PR DESCRIPTION
<!-- Title of PR should use a standard commit prefix (feat, fix, chore, docs, test, etc.) followed by an optional context ((components), (linting), etc), and a succinct description. I.E. `feat(components): add MyFancyComponent` or `fix(search/results): incomplete results displayed` -->

<!-- Does not have to match PR title. I.E. MyFancyComponent -->

# Fix home page misalignment

<!-- What is the rationale for the changes? -->

## Background

- Noticed layout was broken when smoke-testing v2 release

<!-- What is the description of the changes? -->

## Description

- Removes `pdap-grid-container` class and uses tailwind classes directly.

## Acceptance Criteria

<!-- What are the steps to test the changes? -->

1. Run app, open in safari
2. To see difference, visit `pdap.io` or `pdap.dev` in any Safari browser.
