### PR TITLE
fix: footer floats with short content

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -59,7 +59,7 @@ provide('footerLinks', FOOTER_LINKS);
 
 main {
   @apply relative;
-  min-height: calc(100vh - 200px);
+  min-height: calc(100vh - 100px);
 }
 
 .route-fade-enter-active,


### PR DESCRIPTION
<!-- Title of PR should use a standard commit prefix (feat, fix, chore, docs, test, etc.) followed by an optional context ((components), (linting), etc), and a succinct description. I.E. `feat(components): add MyFancyComponent` or `fix(search/results): incomplete results displayed` -->

<!-- Does not have to match PR title. I.E. MyFancyComponent -->

# Footer not stuck to bottom of viewport on large screens

<!-- What is the rationale for the changes? -->

## Background

- After header and footer updates, the default min height of our `main` elements is no longer large enough, resulting in the footer appearing to float off the bottom bar.

<img width="1164" alt="Screenshot 2025-02-04 at 9 54 46 AM" src="https://github.com/user-attachments/assets/5bc97fc5-026c-41d1-85d7-2510de1e3ae1" />

<!-- What is the description of the changes? -->

## Description

- Increases min height of `main` element to compensate

## Acceptance Criteria

<!-- What are the steps to test the changes? -->

1. Run app, ensure footer always appears at least at the bottom of the viewport, even when shorter content contained in the `main` element.
