### PR TITLE
fix: use display name for all typeahead formatting

### DIFF
--- a/src/api/data-requests.js
+++ b/src/api/data-requests.js
@@ -103,7 +103,7 @@ export async function getRecentRequests() {
     isCachedResponseValid({
       cacheTime: cached.timestamp,
       // Cache for 3 minutes
-      intervalBeforeInvalidation: 1000 * 60 * 3,
+      intervalBeforeInvalidation: 1000 * 60 * 3
     })
   ) {
     return cached.data;
@@ -111,7 +111,7 @@ export async function getRecentRequests() {
 
   const params = {
     sort_by: 'date_created',
-    sort_order: 'DESC',
+    sort_order: 'DESC'
     // requested_columns: 'id,title', // Was not working, see data-sources-app/issues/581
     // request_statuses: 'Intake', // Used for testing, should be 'Ready to start'
     // limit: 3, // Not supported, see data-sources-app/issues/579
@@ -119,19 +119,17 @@ export async function getRecentRequests() {
 
   const response = await axios.get(REQUESTS_BASE, {
     headers: HEADERS_BASIC,
-    params,
+    params
   });
 
-  const recentRequests = response.data.data
-    .slice(0, 3)
-    .map((item) => ({
-      id: item.id,
-      title: item.title,
-      status: item.request_status,
-      locationDisplayName:
-        item.locations?.[0]?.display_name || 'Unknown location',
-      route: `/data-request/${item.id}`,
-    }));
+  const recentRequests = response.data.data.slice(0, 3).map((item) => ({
+    id: item.id,
+    title: item.title,
+    status: item.request_status,
+    locationDisplayName:
+      item.locations?.[0]?.display_name || 'Unknown location',
+    route: `/data-request/${item.id}`
+  }));
 
   requestsStore.setDataRequestToCache('recent-requests', recentRequests);
 

--- a/src/components/SearchForm.vue
+++ b/src/components/SearchForm.vue
@@ -4,7 +4,7 @@
     <TypeaheadInput
       :id="TYPEAHEAD_ID"
       ref="typeaheadRef"
-      :format-item-for-display="getFullLocationText"
+      :format-item-for-display="(item) => item.display_name"
       :items="items"
       :placeholder="placeholder ?? 'Enter a place'"
       @select-item="onSelectRecord"
@@ -17,7 +17,7 @@
       <!-- Item to render passed as scoped slot -->
       <template #item="item">
         <!-- eslint-disable-next-line vue/no-v-html This data is coming from our API, so we can trust it-->
-        <span v-html="typeaheadRef?.boldMatchText(getFullLocationText(item))" />
+        <span v-html="typeaheadRef?.boldMatchText(item.display_name)" />
         <span class="locale-type">
           {{ item.type }}
         </span>
@@ -72,7 +72,6 @@ import {
 import TypeaheadInput from '@/components/TypeaheadInput.vue';
 import { computed, onMounted, ref } from 'vue';
 import {
-  getFullLocationText,
   mapLocationToSearchParams,
   mapSearchParamsToLocation
 } from '@/util/locationFormatters';

--- a/src/pages/data-request/create.vue
+++ b/src/pages/data-request/create.vue
@@ -38,7 +38,7 @@
           v-for="location in selectedLocations"
           :key="JSON.stringify(location)"
           class="md:col-span-2"
-          :content="getFullLocationText(location)"
+          :content="location.display_name"
           :on-click="
             () => {
               const indexToRemove = selectedLocations.indexOf(location);
@@ -53,7 +53,7 @@
         ref="typeaheadRef"
         class="md:col-span-2"
         :error="typeaheadError"
-        :format-item-for-display="getFullLocationText"
+        :format-item-for-display="(item) => item.display_name"
         :items="items"
         :placeholder="
           selectedLocations.length ? 'Enter another place' : 'Enter a place'
@@ -71,8 +71,7 @@
         @on-input="fetchTypeaheadResults">
         <!-- Item to render passed as scoped slot -->
         <template #item="item">
-          <span
-            v-html="typeaheadRef?.boldMatchText(getFullLocationText(item))" />
+          <span v-html="typeaheadRef?.boldMatchText(item.display_name)" />
           <span class="locale-type">
             {{ item.type }}
           </span>
@@ -169,7 +168,6 @@ import Typeahead from '@/components/TypeaheadInput.vue';
 import LocationSelected from '@/components/TypeaheadSelected.vue';
 import { toast } from 'vue3-toastify';
 import { createRequest } from '@/api/data-requests';
-import { getFullLocationText } from '@/util/locationFormatters';
 import _debounce from 'lodash/debounce';
 import _cloneDeep from 'lodash/cloneDeep';
 import { nextTick, ref, watch } from 'vue';
@@ -385,7 +383,7 @@ h4 {
 }
 
 .locale-type {
-  @apply border-solid border-2 border-neutral-700 dark:border-neutral-400 rounded-full text-neutral-700 dark:text-neutral-400 text-xs @md:text-sm px-2 py-1;
+  @apply border-solid border-2 border-neutral-700 dark:border-neutral-400 rounded-full text-neutral-700 dark:text-neutral-400 text-xs @md: text-sm px-2 py-1;
 }
 
 .list-move,

--- a/src/pages/data-request/create.vue
+++ b/src/pages/data-request/create.vue
@@ -383,7 +383,7 @@ h4 {
 }
 
 .locale-type {
-  @apply border-solid border-2 border-neutral-700 dark:border-neutral-400 rounded-full text-neutral-700 dark:text-neutral-400 text-xs @md: text-sm px-2 py-1;
+  @apply border-solid border-2 border-neutral-700 dark:border-neutral-400 rounded-full text-neutral-700 dark:text-neutral-400 text-xs @md:text-sm px-2 py-1;
 }
 
 .list-move,


### PR DESCRIPTION
<!-- Title of PR should use a standard commit prefix (feat, fix, chore, docs, test, etc.) followed by an optional context ((components), (linting), etc), and a succinct description. I.E. `feat(components): add MyFancyComponent` or `fix(search/results): incomplete results displayed` -->

<!-- Does not have to match PR title. I.E. MyFancyComponent -->

# Use display name for formatting

<!-- What is the rationale for the changes? -->

## Background

- Moved location formatting to API, this client change just builds that work already done by @maxachis to standardize these responses.
- Further simplification of location formatting is coming as a sidecar to the work being done in #198 , at which point we can remove a lot of the complex logic around this from the client.

<!-- What is the description of the changes? -->

## Description

- Removes location formatting function calls and accesses `display_name` directly

## Acceptance Criteria

<!-- What are the steps to test the changes? -->

1. Run app
2. Ensure locations returned by typeahead are formatted as expected for display
