### PR TITLE
feat(signup): Signup feature flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ VITE_V2_FEATURE_ENHANCED_SEARCH=enabled
 VITE_V2_FEATURE_AUTHENTICATE=enabled
 VITE_V2_FEATURE_CREATE_RECORDS=enabled
 VITE_V2_FEATURE_SHOW_REQUESTS=enabled
+VITE_V2_FEATURE_SIGNUP=enabled
 ```
 
 _Note: You can also override these vars when starting the dev server if you'd rather not update an env file every time you need a different value, by passing the value to the command line before running the server i.e:_ `VITE_API_URL=localhost:5000 npm run dev`

--- a/src/pages/sign-up/index.vue
+++ b/src/pages/sign-up/index.vue
@@ -1,6 +1,6 @@
 <template>
   <main class="pdap-flex-container mx-auto max-w-2xl">
-    <template v-if="!auth.userId">
+    <template v-if="!auth.userId && getIsV2FeatureEnabled('SIGNUP')">
       <h1>Sign Up</h1>
 
       <!-- TODO: when GH auth is complete, encapsulate duplicate UI from this and `/sign-up` -->
@@ -79,7 +79,7 @@
             class="pdap-button-secondary flex-1 max-w-full"
             data-test="toggle-button"
             to="/sign-in">
-            Log in
+            Sign in
           </RouterLink>
           <RouterLink
             class="pdap-button-secondary flex-1 max-w-full"
@@ -90,7 +90,21 @@
         </div>
       </template>
     </template>
+    <template v-else-if="!auth.userId && !getIsV2FeatureEnabled('SIGNUP')">
+      <h1>We're in a controlled beta.</h1>
+      <p>...but we'd love to have you! If you'd like to create an account, email <a href="mailto:contact@pdap.io">contact@pdap.io</a>.</p>
+      <div
+          class="flex flex-col items-start gap-3 sm:flex-row sm:items-center sm:gap-4 sm:flex-wrap w-full">
+          <p class="w-full max-w-[unset]">Already have an account?</p>
 
+          <RouterLink
+            class="pdap-button-primary flex-1"
+            data-test="toggle-button"
+            to="/sign-in">
+            Sign in
+          </RouterLink>
+        </div>
+    </template>
     <RouterView v-else />
   </main>
 </template>
@@ -112,6 +126,7 @@ import { useRoute, RouterView, useRouter } from 'vue-router';
 import { useMutation } from '@tanstack/vue-query';
 import { useAuthStore } from '@/stores/auth';
 import { signInWithGithub, signUpWithEmail, beginOAuthLogin } from '@/api/auth';
+import { getIsV2FeatureEnabled } from '@/util/featureFlagV2';
 
 const auth = useAuthStore();
 const route = useRoute();

--- a/src/pages/sign-up/index.vue
+++ b/src/pages/sign-up/index.vue
@@ -92,18 +92,22 @@
     </template>
     <template v-else-if="!auth.userId && !getIsV2FeatureEnabled('SIGNUP')">
       <h1>We're in a controlled beta.</h1>
-      <p>...but we'd love to have you! If you'd like to create an account, email <a href="mailto:contact@pdap.io">contact@pdap.io</a>.</p>
+      <p>
+        ...but we'd love to have you! If you'd like to create an account, email
+        <a href="mailto:contact@pdap.io">contact@pdap.io</a>
+        .
+      </p>
       <div
-          class="flex flex-col items-start gap-3 sm:flex-row sm:items-center sm:gap-4 sm:flex-wrap w-full">
-          <p class="w-full max-w-[unset]">Already have an account?</p>
+        class="flex flex-col items-start gap-3 sm:flex-row sm:items-center sm:gap-4 sm:flex-wrap w-full">
+        <p class="w-full max-w-[unset]">Already have an account?</p>
 
-          <RouterLink
-            class="pdap-button-primary flex-1"
-            data-test="toggle-button"
-            to="/sign-in">
-            Sign in
-          </RouterLink>
-        </div>
+        <RouterLink
+          class="pdap-button-primary flex-1"
+          data-test="toggle-button"
+          to="/sign-in">
+          Sign in
+        </RouterLink>
+      </div>
     </template>
     <RouterView v-else />
   </main>

--- a/src/util/featureFlagV2.js
+++ b/src/util/featureFlagV2.js
@@ -1,7 +1,7 @@
 /**
  * Gets enabled / disabled status for features.
  *
- * @param {'ENHANCED_SEARCH' | 'AUTHENTICATE' | 'CREATE_RECORDS' | 'SHOW_REQUESTS'} featureName Name of V2 feature to check
+ * @param {'ENHANCED_SEARCH' | 'AUTHENTICATE' | 'CREATE_RECORDS' | 'SHOW_REQUESTS' | 'SIGNUP'} featureName Name of V2 feature to check
  * @returns {boolean} Whether the feature is enabled or not
  */
 export function getIsV2FeatureEnabled(featureName) {


### PR DESCRIPTION

<img width="610" alt="Screen Shot 2025-03-13 at 4 30 38 PM" src="https://github.com/user-attachments/assets/513c0f33-d7c7-4034-bb9a-d6852e3abce9" />


<!-- Title of PR should use a standard commit prefix (feat, fix, chore, docs, test, etc.) followed by an optional context ((components), (linting), etc), and a succinct description. I.E. `feat(components): add MyFancyComponent` or `fix(search/results): incomplete results displayed` -->

<!-- Does not have to match PR title. I.E. MyFancyComponent -->

# Sign up feature flag

<!-- What is the rationale for the changes? -->

## Background

- https://github.com/Police-Data-Accessibility-Project/data-sources-app/issues/543
- we want to allow people to sign up and sign in, but we'll create accounts for them. if someone is clever enough to use the API, that's OK—I will get an email notification that they have signed up.

<!-- What is the description of the changes? -->

## Description

- Adds a feature flag with envar

## Acceptance Criteria

<!-- What are the steps to test the changes? -->

- it's currently set to DISABLED in `dev` and `prod`; test to see if you're able to sign up!