### PR TITLE
#258: Fix data source form submission handling of advanced properties so it…

### DIFF
--- a/src/pages/data-source/create.vue
+++ b/src/pages/data-source/create.vue
@@ -750,7 +750,6 @@ const createDataSourceMutation = useMutation({
     await createDataSource(formValues);
 
     window.scrollTo(0, 0);
-    advancedPropertiesExpanded.value = false;
     const message = `${formValues.entry_data[INPUT_NAMES.name]} has been submitted successfully!\nIt will be available in our data sources database after approval.`;
     toast.success(message, { autoClose: false });
   },
@@ -762,6 +761,7 @@ const createDataSourceMutation = useMutation({
       queryKey: [SEARCH]
     });
     selectedAgencies.value = [];
+    requestPending.value = false;
   },
   onError: (error) => {
     if (error) {


### PR DESCRIPTION
Fix for https://github.com/Police-Data-Accessibility-Project/pdap.io/issues/258

A few flags were being handled in a way that caused this buggy advanced properties behavior. I updated it so the properties panel remains open when the form is submitted and the show/hide button doesn't get disabled.