### PR TITLE
fix: set up environment variable for MSW

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,10 @@ VITE_V2_FEATURE_AUTHENTICATE=enabled
 VITE_V2_FEATURE_CREATE_RECORDS=enabled
 VITE_V2_FEATURE_SHOW_REQUESTS=enabled
 VITE_V2_FEATURE_SIGNUP=enabled
+
+# Include the below only if you want to use Mock Service Worker to mock API responses
+# This should not be included in production
+VITE_MSW_ENABLED=true
 ```
 
 _Note: You can also override these vars when starting the dev server if you'd rather not update an env file every time you need a different value, by passing the value to the command line before running the server i.e:_ `VITE_API_URL=localhost:5000 npm run dev`

--- a/src/main.js
+++ b/src/main.js
@@ -12,16 +12,15 @@ import './main.css';
 import 'vue3-toastify/dist/index.css';
 import 'pdap-design-system/styles';
 
-async function enableMocking() {
-  if (import.meta.env.MODE === 'development') {
-    console.log('Running in development mode');
+async function optionallyEnableMocking() {
+  if (import.meta.env.VITE_MSW_ENABLED) {
     const { worker } = await import('./mocks/browser');
     await worker.start();
   }
 }
 
 // Ensure MSW starts before mounting the app
-enableMocking().then(() => {
+optionallyEnableMocking().then(() => {
   /* Plugins, etc. -- order matters */
   const app = createApp(App);
 


### PR DESCRIPTION
# Add `VITE_MSW_ENABLED` environment variable

## Background

- Previously, MSW was enabled by using `npm run build -- mode development`.
- However, because we may use development mode for some live environments, this was judged to be not what we wanted. 

## Description

- Replace use of `MODE == 'development' for enabling MSW with an explicit environment variable, `VITE_MSW_ENABLED`

## Acceptance Criteria

1. Using `npm run build -- --mode development` should not enable MSW