### PR TITLE
fix: password reset flow

### DIFF
--- a/src/pages/profile/index.vue
+++ b/src/pages/profile/index.vue
@@ -34,7 +34,7 @@
             <div class="h-12">
               <router-link
                 class="pdap-button-secondary"
-                :to="'/request-reset-password'">
+                :to="'/change-password'">
                 Reset your password
               </router-link>
             </div>

--- a/src/pages/request-reset-password.vue
+++ b/src/pages/request-reset-password.vue
@@ -73,7 +73,7 @@ const {
     await requestPasswordReset(email);
   },
   onSuccess: () => {
-    toast.success('Password updated successfully');
+    toast.success('Password reset request received');
   },
   onError: (err) => {
     toast.error(err.message ?? 'Something went wrong. Please try again.');


### PR DESCRIPTION
<!-- Title of PR should use a standard commit prefix (feat, fix, chore, docs, test, etc.) followed by an optional context ((components), (linting), etc), and a succinct description. I.E. `feat(components): add MyFancyComponent` or `fix(search/results): incomplete results displayed` -->

<!-- Does not have to match PR title. I.E. MyFancyComponent -->

# Fix password reset flow

<!-- What is the rationale for the changes? -->

## Background
#275 
- Password reset experience had two bugs: one in the toast message, and one in the token

<!-- What is the description of the changes? -->

## Description

- Ensures smooth reset flow end-to-end
Also:
- updates `/reset-password` to redirect to `/request-reset-password` if it is accessed without a token.
- updates `/profile` "Reset password" link to go to `/change-password`, as the reset flow is designed to be used for unauthenticated users, whereas `/change-password` is designed for users who remember their PW and are already logged in.

## Acceptance Criteria

<!-- What are the steps to test the changes? -->

1. Run app, navigate to `/request-reset-password`
2. Complete the flow for any existing email/PW user.
