### PR TITLE
fix: address bug with Link to GitHub not triggering

### DIFF
--- a/src/pages/profile/index.vue
+++ b/src/pages/profile/index.vue
@@ -225,7 +225,7 @@ import { getFullLocationText } from '@/util/locationFormatters';
 import { deleteFollowedSearch } from '@/api/search';
 import { linkAccountWithGithub, signOut, beginOAuthLogin } from '@/api/auth';
 import { getUser } from '@/api/user';
-import { computed, watch } from 'vue';
+import { computed, onMounted} from 'vue';
 import { SEARCH_FOLLOWED } from '@/util/queryKeys';
 
 const route = useRoute();
@@ -360,14 +360,12 @@ const recentSearches = computed(() =>
   })
 );
 
-watch(
-  () => route.query,
-  (newQuery) => {
-    if (newQuery.gh_access_token) {
-      completeGithubAuth();
-    }
+onMounted(() => {
+  if (route.query.gh_access_token) {
+    completeGithubAuth();
+    router.replace({ query: { ...route.query, gh_access_token: undefined } });
   }
-);
+});
 
 async function signOutWithRedirect() {
   auth.setRedirectTo(route);

--- a/src/pages/profile/index.vue
+++ b/src/pages/profile/index.vue
@@ -225,7 +225,7 @@ import { getFullLocationText } from '@/util/locationFormatters';
 import { deleteFollowedSearch } from '@/api/search';
 import { linkAccountWithGithub, signOut, beginOAuthLogin } from '@/api/auth';
 import { getUser } from '@/api/user';
-import { computed, onMounted} from 'vue';
+import { computed, onMounted } from 'vue';
 import { SEARCH_FOLLOWED } from '@/util/queryKeys';
 
 const route = useRoute();


### PR DESCRIPTION
# fix: address bug with Link to GitHub not triggering

## Background

Previously, the Link to GitHub button was not triggering a call to the `/oauth/link-to-github` endpoint.

After closer inspection, I observed that the watch function was not firing. This is because the watch function only triggers when the observed value changes after the component has been mounted. Thus watch was not picking up on the GitHub access token query parameter, because it technically was not *changed* -- it was already present when the component was mounted after the GitHub redirect.

## Description

- Replaces the `watch` function with `onMounted`, which ensures that the logic triggers on page load. 
- Additionally, after loading under these conditions, the gh_access_token query parameter is now removed, just to keep things clean 🧹

## Acceptance Criteria

1. Log in and navigate to the `/profile` page.
2. Trigger the logic by clicking `Link account with Github` or by loading the page with `gh_access_token=something` as a query parameter
3. Confirm the call to `link-to-github` properly fires.
