### PR TITLE
fix: address bug with comma in federal jurisdictions for `/data-source/{id}`

### DIFF
--- a/src/pages/data-source/[id].vue
+++ b/src/pages/data-source/[id].vue
@@ -94,10 +94,13 @@
                     v-for="agency in dataSource.agencies"
                     :key="agency.county_name?.[0]">
                     {{
-                      typeof agency.county_name === 'string'
-                        ? agency.county_name
-                        : agency.county_name?.join(', ')
-                    }}, {{ agency.state_iso }}
+                      agency.county_name
+                        ? (typeof agency.county_name === 'string'
+                            ? agency.county_name
+                            : agency.county_name?.join(', ')) +
+                          (agency.state_iso ? ', ' : '')
+                        : ''
+                    }}{{ agency.state_iso }}
                   </p>
                 </div>
                 <div>


### PR DESCRIPTION
…
Previously, a comma was appearing in the `County, State` section when no county or state was present. This ensures that comma is not present under those conditions.

# fix: address bug with comma in federal jurisdictions for `/data-source/{id}`

## Background

- Problem that needed solving
- or bug that needed fixing
- etc.

<!-- What is the description of the changes? -->

## Description

- Adds this
- Removes that

## Acceptance Criteria

<!-- What are the steps to test the changes? -->

1. Do this
2. then that
3. then 🚀🚀🚀
