### PR TITLE
fix: correct spelling from "Github" to "GitHub"

### DIFF
--- a/src/pages/change-password.vue
+++ b/src/pages/change-password.vue
@@ -15,7 +15,7 @@
     <!-- GH auth user - no password to change -->
     <template v-if="profileData?.external_accounts.github">
       <p>
-        You signed up with a Github account linked to the email address you
+        You signed up with a GitHub account linked to the email address you
         provided. No password is necessary to access your account.
       </p>
       <p>

--- a/src/pages/data-request/[id].vue
+++ b/src/pages/data-request/[id].vue
@@ -73,7 +73,7 @@
             class="pdap-button-primary mt-2 mb-4"
             _target="blank"
             rel="noreferrer">
-            Help out with this issue on Github
+            Help out with this issue on GitHub
             <FontAwesomeIcon :icon="faLink" />
           </a>
         </template>

--- a/src/pages/profile/index.vue
+++ b/src/pages/profile/index.vue
@@ -42,7 +42,7 @@
 
           <!-- Github info -->
           <section>
-            <h3 class="like-h4">Github account</h3>
+            <h3 class="like-h4">GitHub account</h3>
             <div
               :class="{
                 'profile-loading h-12': !profileData && profileLoading
@@ -51,7 +51,7 @@
                 v-if="didLinkGithub || profileData?.external_accounts.github">
                 <p>
                   <FontAwesomeIcon :icon="faGithub" />
-                  Your account is linked with Github
+                  Your account is linked with GitHub
                 </p>
               </template>
 
@@ -63,7 +63,7 @@
                   intent="tertiary"
                   @click="async () => await beginOAuthLogin('/profile')">
                   <FontAwesomeIcon :icon="faGithub" />
-                  Link account with Github
+                  Link account with GitHub
                 </Button>
               </template>
             </div>
@@ -146,7 +146,7 @@
               @keydown.stop.enter=""
               @click.stop="">
               <FontAwesomeIcon :icon="faLink" />
-              Github
+              GitHub
             </a>
           </template>
         </ProfileTable>
@@ -279,7 +279,7 @@ const {
   },
   onSuccess: (data) => {
     if (data) {
-      toast.success('Successfully linked Github account');
+      toast.success('Successfully linked GitHub account');
     }
     queryClient.invalidateQueries({ queryKey: [PROFILE] });
   }

--- a/src/pages/search/_components/Requests.vue
+++ b/src/pages/search/_components/Requests.vue
@@ -41,7 +41,7 @@
           @keydown.stop.enter=""
           @click.stop="">
           <FontAwesomeIcon :icon="faLink" />
-          Github
+          GitHub
         </a>
       </div>
     </RouterLink>

--- a/src/pages/sign-in.vue
+++ b/src/pages/sign-in.vue
@@ -20,14 +20,14 @@
     <template v-else>
       <template v-if="isGithubAuthError">
         <p class="error">
-          There was an error logging you in with Github. Please try again
+          There was an error logging you in with GitHub. Please try again
         </p>
       </template>
       <template v-else>
         <template v-if="githubAuthData?.userExists">
           <p class="error">
             You already have an account with this email address. Please sign in
-            and link your existing account to Github from your profile.
+            and link your existing account to GitHub from your profile.
           </p>
         </template>
 
@@ -37,7 +37,7 @@
           :disabled="githubAuthData?.userExists"
           @click="async () => await beginOAuthLogin()">
           <FontAwesomeIcon :icon="faGithub" />
-          Sign in with Github
+          Sign in with GitHub
         </Button>
       </template>
 

--- a/src/pages/sign-up/index.vue
+++ b/src/pages/sign-up/index.vue
@@ -13,7 +13,7 @@
       <template v-else>
         <template v-if="isGithubAuthError">
           <p class="error">
-            There was an error logging you in with Github. Please try again
+            There was an error logging you in with GitHub. Please try again
           </p>
         </template>
         <template v-else>
@@ -21,7 +21,7 @@
             <p class="error">
               You already have an account with this email address. Please
               <RouterLink to="/profile">sign in</RouterLink>
-              and link your existing account to Github from your profile.
+              and link your existing account to GitHub from your profile.
             </p>
           </template>
 
@@ -31,7 +31,7 @@
             :disabled="githubAuthData?.userExists"
             @click="async () => await beginOAuthLogin('/sign-up')">
             <FontAwesomeIcon :icon="faGithub" />
-            Sign up with Github
+            Sign up with GitHub
           </Button>
         </template>
 

--- a/src/util/constants.js
+++ b/src/util/constants.js
@@ -30,7 +30,7 @@ export const NAV_LINKS = [
 export const FOOTER_LINKS = [
   {
     href: 'https://github.com/orgs/Police-Data-Accessibility-Project',
-    text: 'Github',
+    text: 'GitHub',
     icon: FOOTER_LINK_ICONS.GITHUB
   },
   {


### PR DESCRIPTION
# fix: correct spelling from "Github" to "GitHub"

## Background

- https://github.com/Police-Data-Accessibility-Project/pdap.io/issues/282
- The technically correct spelling is `GitHub`, not `Github`, so public-facing instances should be changed so we look profesh.

## Description

- Changes public-facing usages of "Github" to "GitHub"

## Acceptance Criteria

1. Visually inspect website and confirm change of nomenclature
