### PR TITLE
fix: adjust /data-source/{id} page to better handle large numbers of associated agencies.

### DIFF
--- a/src/api/data-sources.js
+++ b/src/api/data-sources.js
@@ -11,9 +11,25 @@ const HEADERS_BASIC = {
 };
 
 export async function getDataSource(id) {
-  return await axios.get(`${DATA_SOURCES_BASE}/${id}`, {
+  const result = await axios.get(`${DATA_SOURCES_BASE}/${id}`, {
     headers: HEADERS_BASIC
   });
+  const unique_jurisdictions = [];
+  const unique_agency_type = [];
+
+  result.data.data.agencies.forEach((agency) => {
+    if (!unique_jurisdictions.includes(agency.jurisdiction_type)) {
+      unique_jurisdictions.push(agency.jurisdiction_type);
+    }
+
+    if (!unique_agency_type.includes(agency.agency_type)) {
+      unique_agency_type.push(agency.agency_type);
+    }
+  });
+
+  result.data.data.unique_jurisdictions = unique_jurisdictions;
+  result.data.data.unique_agency_type = unique_agency_type;
+  return result;
 }
 
 export async function createDataSource(data) {

--- a/src/pages/data-source/[id].vue
+++ b/src/pages/data-source/[id].vue
@@ -78,43 +78,71 @@
           <div class="flex-[0_0_100%] flex flex-col w-full">
             <div
               ref="agenciesRef"
-              class="w-full self-start justify-self-start mb-4 border border-neutral-300 rounded p-2">
-              <table class="w-full border-collapse">
-                <thead>
-                  <tr>
-                    <th class="text-left w-1/3"><h4>Agency</h4></th>
-                    <th class="text-left w-1/3"><h4>County, State</h4></th>
-                  </tr>
-                </thead>
-              </table>
-              <div class="max-h-[250px] overflow-y-auto">
-                <table class="w-full border-collapse">
-                  <tbody>
-                    <tr
-                      v-for="agency in dataSource.agencies"
-                      :key="agency.submitted_name"
-                      class="">
-                      <td class="p-2 w-1/3">{{ agency.submitted_name }}</td>
-                      <td class="p-2 w-1/3">
-                        {{
-                          typeof agency.county_name === 'string'
-                            ? agency.county_name
-                            : agency.county_name?.join(', ')
-                        }}, {{ agency.state_iso }}
-                      </td>
+              class="w-full self-start justify-self-start mb-4">
+              <!-- 👤 Single agency: original layout -->
+              <template v-if="dataSource.agencies.length === 1">
+                <div class="inline-flex flex-wrap gap-8 [&>div]:w-max">
+                  <div>
+                    <h4 class="m-0">Agency</h4>
+                    <p>{{ dataSource.agencies[0].submitted_name }}</p>
+                  </div>
+                  <div>
+                    <h4 class="m-0">County, State</h4>
+                    <p>
+                      {{
+                        typeof dataSource.agencies[0].county_name === 'string'
+                          ? dataSource.agencies[0].county_name
+                          : dataSource.agencies[0].county_name?.join(', ')
+                      }}, {{ dataSource.agencies[0].state_iso }}
+                    </p>
+                  </div>
+                  <div>
+                    <h4 class="m-0">Agency Type</h4>
+                    <p class="capitalize">{{ dataSource.agencies[0].agency_type }}</p>
+                  </div>
+                </div>
+              </template>
+
+              <!-- 📊 Multiple agencies: table layout with scrollable body -->
+
+              <template v-else>
+                <table class="w-full border-collapse border-b">
+                  <thead>
+                    <tr>
+                      <th class="text-left w-1/3"><h4>Agency</h4></th>
+                      <th class="text-left w-1/3"><h4>County, State</h4></th>
                     </tr>
-                  </tbody>
+                  </thead>
                 </table>
-              </div>
-              <div>
-                <h4 class="m-0">Agency Type</h4>
-                <p
-                  v-for="agency_type in dataSource.unique_agency_type"
-                  :key="agency_type"
-                  class="capitalize">
-                  {{ agency_type }}
-                </p>
-              </div>
+                <div class="max-h-[250px] overflow-y-auto border-b">
+                  <table class="w-full border-collapse ">
+                    <tbody>
+                      <tr
+                        v-for="agency in dataSource.agencies"
+                        :key="agency.submitted_name"
+                        class="">
+                        <td class="w-1/3">{{ agency.submitted_name }}</td>
+                        <td class="w-1/3">
+                          {{
+                            typeof agency.county_name === 'string'
+                              ? agency.county_name
+                              : agency.county_name?.join(', ')
+                          }}, {{ agency.state_iso }}
+                        </td>
+                      </tr>
+                    </tbody>
+                  </table>
+                </div>
+                <div>
+                  <h4 class="m-0">Agency Type</h4>
+                  <p
+                    v-for="agency_type in dataSource.unique_agency_type"
+                    :key="agency_type"
+                    class="capitalize">
+                    {{ agency_type }}
+                  </p>
+                </div>
+              </template>
             </div>
             <a
               :href="dataSource.source_url"

--- a/src/pages/data-source/[id].vue
+++ b/src/pages/data-source/[id].vue
@@ -43,10 +43,10 @@
                 {{ dataSource.record_type_name }}
               </p>
               <p
-                v-for="agency in dataSource.agencies"
-                :key="agency.jurisdiction_type"
+                v-for="jurisdiction_type in dataSource.unique_jurisdictions"
+                :key="jurisdiction_type"
                 class="pill">
-                Jurisdiction: {{ agency.jurisdiction_type }}
+                Jurisdiction: {{ jurisdiction_type }}
               </p>
               <template v-if="Array.isArray(dataSource.tags)">
                 <p v-for="tag in dataSource.tags" :key="tag" class="pill w-max">
@@ -78,37 +78,42 @@
           <div class="flex-[0_0_100%] flex flex-col w-full">
             <div
               ref="agenciesRef"
-              class="w-full self-start justify-self-start mb-4">
-              <div class="inline-flex flex-wrap gap-8 [&>div]:w-max">
-                <div>
-                  <h4 class="m-0">Agency</h4>
-                  <p
-                    v-for="agency in dataSource.agencies"
-                    :key="agency.submitted_name">
-                    {{ agency.submitted_name }}
-                  </p>
-                </div>
-                <div>
-                  <h4 class="m-0">County, State</h4>
-                  <p
-                    v-for="agency in dataSource.agencies"
-                    :key="agency.county_name?.[0]">
-                    {{
-                      typeof agency.county_name === 'string'
-                        ? agency.county_name
-                        : agency.county_name?.join(', ')
-                    }}, {{ agency.state_iso }}
-                  </p>
-                </div>
-                <div>
-                  <h4 class="m-0">Agency Type</h4>
-                  <p
-                    v-for="agency in dataSource.agencies"
-                    :key="agency.agency_type"
-                    class="capitalize">
-                    {{ agency.agency_type }}
-                  </p>
-                </div>
+              class="w-full self-start justify-self-start mb-4 border border-neutral-300 rounded p-2">
+              <table class="w-full border-collapse">
+                <thead>
+                  <tr>
+                    <th class="text-left w-1/3"><h4>Agency</h4></th>
+                    <th class="text-left w-1/3"><h4>County, State</h4></th>
+                  </tr>
+                </thead>
+              </table>
+              <div class="max-h-[250px] overflow-y-auto">
+                <table class="w-full border-collapse">
+                  <tbody>
+                    <tr
+                      v-for="agency in dataSource.agencies"
+                      :key="agency.submitted_name"
+                      class="">
+                      <td class="p-2 w-1/3">{{ agency.submitted_name }}</td>
+                      <td class="p-2 w-1/3">
+                        {{
+                          typeof agency.county_name === 'string'
+                            ? agency.county_name
+                            : agency.county_name?.join(', ')
+                        }}, {{ agency.state_iso }}
+                      </td>
+                    </tr>
+                  </tbody>
+                </table>
+              </div>
+              <div>
+                <h4 class="m-0">Agency Type</h4>
+                <p
+                  v-for="agency_type in dataSource.unique_agency_type"
+                  :key="agency_type"
+                  class="capitalize">
+                  {{ agency_type }}
+                </p>
               </div>
             </div>
             <a


### PR DESCRIPTION
# fix: adjust /data-source/{id} page to better handle large numbers of associated agencies.

## Background

- For data sources with a large number of associated agencies, such as [Stanford Open Policing Project stops dashboard](https://pdap.dev/data-source/1484), the display would be broken in multiple ways
  - The description could overflow past the typical width boundaries
  - A large number of agencies would clutter the screen
  - The `Agency Type` section would be pushed to the bottom and removed of visual context
  - Redundant jurisdictions would clutter the jurisdiction header.

## Description

- Adds conditional logic such that, if there is only one associated agency, the display remains the same
- Otherwise, in the case of multiple associated agencies:
  - The jurisdictions are consolidated such that only one of each unique jurisdiction is displayed
  - The Agency/County, State sections are converted to a scrollable tabular view, with a fixed heading.
  - The agency types, like the jurisdictions, are consolidated to only display one of each unique agency type.

## Acceptance Criteria

1. Visually inspect changes on cases such as the Stanford Open Policing Project and confirm that the changes described above occur and match with the images below
2. Confirm that for other data sources with only one associated agency, the display is unchanged.

## Images

### Stanford Desktop New
![stanford_desktop_new](https://github.com/user-attachments/assets/51228d77-cd61-4d2f-b12e-7e2ca5f2f6cf)
### Stanford Desktop Old
![stanford_desktop_old](https://github.com/user-attachments/assets/96f6b555-55e1-49ec-acbd-14e59ab47085)
### Stanford Mobile New
![stanford_mobile_new](https://github.com/user-attachments/assets/cf45f483-a494-4593-a9f7-3af519008ba7)
### Stanford Mobile Old
![stanford_mobile_old](https://github.com/user-attachments/assets/7dd5aa64-355b-471d-95d7-b409f9b6a8d0)
