### PR TITLE
signup envar to url param

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,6 @@ VITE_V2_FEATURE_ENHANCED_SEARCH=enabled
 VITE_V2_FEATURE_AUTHENTICATE=enabled
 VITE_V2_FEATURE_CREATE_RECORDS=enabled
 VITE_V2_FEATURE_SHOW_REQUESTS=enabled
-VITE_V2_FEATURE_SIGNUP=enabled
 ```
 
 _Note: You can also override these vars when starting the dev server if you'd rather not update an env file every time you need a different value, by passing the value to the command line before running the server i.e:_ `VITE_API_URL=localhost:5000 npm run dev`

--- a/src/pages/profile/index.vue
+++ b/src/pages/profile/index.vue
@@ -35,7 +35,12 @@
               <router-link
                 class="pdap-button-secondary"
                 :to="'/change-password'">
-                Reset your password
+                Create a new password
+              </router-link>
+              <router-link
+                class="pdap-button-secondary"
+                :to="'/request-reset-password'">
+                Reset your password via email
               </router-link>
             </div>
           </section>

--- a/src/pages/profile/index.vue
+++ b/src/pages/profile/index.vue
@@ -35,12 +35,7 @@
               <router-link
                 class="pdap-button-secondary"
                 :to="'/change-password'">
-                Create a new password
-              </router-link>
-              <router-link
-                class="pdap-button-secondary"
-                :to="'/request-reset-password'">
-                Reset your password via email
+                Reset your password
               </router-link>
             </div>
           </section>

--- a/src/pages/sign-up/index.vue
+++ b/src/pages/sign-up/index.vue
@@ -1,6 +1,6 @@
 <template>
   <main class="pdap-flex-container mx-auto max-w-2xl">
-    <template v-if="!auth.userId && getIsV2FeatureEnabled('SIGNUP')">
+    <template v-if="!auth.userId && canAccessBeta">
       <h1>Sign Up</h1>
 
       <!-- TODO: when GH auth is complete, encapsulate duplicate UI from this and `/sign-up` -->
@@ -90,7 +90,7 @@
         </div>
       </template>
     </template>
-    <template v-else-if="!auth.userId && !getIsV2FeatureEnabled('SIGNUP')">
+    <template v-else-if="!auth.userId && !canAccessBeta">
       <h1>We're in a controlled beta.</h1>
       <p>
         ...but we'd love to have you! If you'd like to create an account, email
@@ -125,17 +125,23 @@ import {
 import PasswordValidationChecker from '@/components/PasswordValidationChecker.vue';
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
 import { faGithub } from '@fortawesome/free-brands-svg-icons';
-import { ref, watch } from 'vue';
+import { ref, watch, onMounted } from 'vue';
 import { useRoute, RouterView, useRouter } from 'vue-router';
 import { useMutation } from '@tanstack/vue-query';
 import { useAuthStore } from '@/stores/auth';
 import { signInWithGithub, signUpWithEmail, beginOAuthLogin } from '@/api/auth';
-import { getIsV2FeatureEnabled } from '@/util/featureFlagV2';
 
 const auth = useAuthStore();
 const route = useRoute();
 const router = useRouter();
 // Constants
+
+// temporary beta access url param checker
+const canAccessBeta = ref(false);
+onMounted(() => {
+  const route = useRoute();
+  canAccessBeta.value = route.query.beta === 'true';
+});
 const PASSWORD_INPUTS = [
   {
     autocomplete: 'new-password',

--- a/src/util/featureFlagV2.js
+++ b/src/util/featureFlagV2.js
@@ -1,7 +1,7 @@
 /**
  * Gets enabled / disabled status for features.
  *
- * @param {'ENHANCED_SEARCH' | 'AUTHENTICATE' | 'CREATE_RECORDS' | 'SHOW_REQUESTS' | 'SIGNUP'} featureName Name of V2 feature to check
+ * @param {'ENHANCED_SEARCH' | 'AUTHENTICATE' | 'CREATE_RECORDS' | 'SHOW_REQUESTS'} featureName Name of V2 feature to check
  * @returns {boolean} Whether the feature is enabled or not
  */
 export function getIsV2FeatureEnabled(featureName) {


### PR DESCRIPTION
<!-- Title of PR should use a standard commit prefix (feat, fix, chore, docs, test, etc.) followed by an optional context ((components), (linting), etc), and a succinct description. I.E. `feat(components): add MyFancyComponent` or `fix(search/results): incomplete results displayed` -->

<!-- Does not have to match PR title. I.E. MyFancyComponent -->

# Replace signup envar with url param

<!-- What is the rationale for the changes? -->

## Background

- Inspired by https://github.com/Police-Data-Accessibility-Project/data-sources-app/issues/685

<!-- What is the description of the changes? -->

## Description

- replaces the signup envar with a url param so beta access is somewhat controlled, though not all that securely (which is OK)
- now, people are in control of when they get their email validation, and we're not sending them a temp password

<img width="908" alt="Screen Shot 2025-03-25 at 11 12 55 AM" src="https://github.com/user-attachments/assets/9d573ac7-1353-4086-af15-7ef2cf91fb7b" />

<img width="838" alt="Screen Shot 2025-03-25 at 11 13 19 AM" src="https://github.com/user-attachments/assets/a4aaea90-8cd3-4596-8d5f-f88030028bb9" />


## Acceptance Criteria

- try to navigate to /sign-up
- try to navigate to /sign-up?beta=true and observe the difference