### PR TITLE
fix: Ensure see more/see less prompt behaves consistently.

### DIFF
--- a/src/pages/data-source/[id].vue
+++ b/src/pages/data-source/[id].vue
@@ -318,7 +318,7 @@ function getPrev() {
   return searchStore.mostRecentSearchIds[previousIdIndex.value];
 }
 
-let observer = null;
+const observer = ref(null);
 
 watchEffect(() => {
   if (!descriptionRef.value) return;

--- a/src/pages/data-source/[id].vue
+++ b/src/pages/data-source/[id].vue
@@ -345,6 +345,7 @@ onBeforeUnmount(() => {
   if (observer && descriptionRef.value) {
     observer.unobserve(descriptionRef.value);
     observer.disconnect();
+    observer.value = null;
   }
 });
 

--- a/src/pages/data-source/[id].vue
+++ b/src/pages/data-source/[id].vue
@@ -91,10 +91,10 @@
                     <p>
                       {{
                         dataSource.agencies[0].county_name
-                          ? (typeof dataSource.agencies[0].county_name === 'string'
+                          ? (typeof dataSource.agencies[0].county_name ===
+                            'string'
                               ? dataSource.agencies[0].county_name
-                              : dataSource.agencies[0].county_name.join(', ')
-                          ) +
+                              : dataSource.agencies[0].county_name.join(', ')) +
                             (dataSource.agencies[0].state_iso ? ', ' : '')
                           : ''
                       }}
@@ -397,5 +397,10 @@ hgroup {
 .increment-enter-from,
 .decrement-leave-to {
   transform: translateX(15%);
+}
+
+.decrement-enter-from,
+.increment-leave-to {
+  transform: translateX(-15%);
 }
 </style>

--- a/src/pages/data-source/[id].vue
+++ b/src/pages/data-source/[id].vue
@@ -329,7 +329,7 @@ watchEffect(() => {
     showExpandDescriptionButton.value = el.offsetHeight < el.scrollHeight;
   };
 
-  observer = new ResizeObserver(checkOverflow);
+  observer.value = new ResizeObserver(checkOverflow);
   observer.observe(el);
 
   // Also run on initial mount

--- a/src/pages/data-source/[id].vue
+++ b/src/pages/data-source/[id].vue
@@ -330,7 +330,7 @@ watchEffect(() => {
   };
 
   observer.value = new ResizeObserver(checkOverflow);
-  observer.observe(el);
+  observer.value.observe(el);
 
   // Also run on initial mount
   checkOverflow();
@@ -342,9 +342,9 @@ watch(
   }
 );
 onBeforeUnmount(() => {
-  if (observer && descriptionRef.value) {
-    observer.unobserve(descriptionRef.value);
-    observer.disconnect();
+  if (observer.value && descriptionRef.value) {
+    observer.value.unobserve(descriptionRef.value);
+    observer.value.disconnect();
     observer.value = null;
   }
 });


### PR DESCRIPTION

# fix(display): Ensure see more/see less prompt behaves consistently.

## Background

- https://github.com/Police-Data-Accessibility-Project/pdap.io/issues/289

## Description

- Ensure see more/see less prompt behaves consistently by adding 
- Additionally, correct bug in display of comma in County, State column for Federal data sources.
- However, I observed that the "See less" button disappears in the mobile form after "See more" is clicked. This is nonetheless an improvement over how it previously appeared (which is to say, the "See more" button did not appear at all), and out of interest of not changing too much in a single PR, I let it be.

## Acceptance Criteria

1. Inspect `/data-source/{id}` pages
2. Confirm "See more" appears on pages with long descriptions (more than two lines) and does not appear on pages with short descriptions (two lines or less)
3. Confirm, when navigating from a page with a long description to a page with a short description, that the "See more/See less" button does not appear.
