### PR TITLE
More homepage language + move map

### DIFF
--- a/src/components/maps/DataSourceMap.vue
+++ b/src/components/maps/DataSourceMap.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="data-source-map-container">
+  <div class="relative w-full h-auto">
     <div id="map-container" ref="mapContainer" />
     <!-- <span class="loading"></span> -->
     <Spinner

--- a/src/components/maps/styles.css
+++ b/src/components/maps/styles.css
@@ -1,7 +1,4 @@
 /* TODO: add to markup directly where possible */
-.data-source-map-container {
-  @apply relative w-full h-auto;
-}
 
 #map-container {
   @apply w-full h-full relative overflow-hidden;

--- a/src/pages/index.vue
+++ b/src/pages/index.vue
@@ -273,22 +273,21 @@
       <div class="col-span-full">
         <h1>How our data is used</h1>
         <p>
-          Our goal is to make independent research, journalism, and analysis possible by 
-          helping people find the data they need to start any investigation.
+          Our goal is to make independent research, journalism, and analysis
+          possible by helping people find the data they need to start any
+          investigation.
         </p>
       </div>
       <div class="col-span-full pdap-grid-container grid-cols-2 text-lg">
-        <h2 class="my-0 col-span-full">
-          Types of investigative projects
-        </h2>
+        <h2 class="my-0 col-span-full">Types of investigative projects</h2>
         <div>
           <h3>
             <FontAwesomeIcon :icon="faEyeLowVision" />
             Transparency & Oversight
           </h3>
           <p>
-            Misconduct, use of force, complaints, and disciplinary records are some examples 
-            of tools for public oversight and incident reporting.
+            Misconduct, use of force, complaints, and disciplinary records are
+            some examples of tools for public oversight and incident reporting.
           </p>
         </div>
         <div>
@@ -297,8 +296,9 @@
             Operational Analysis
           </h3>
           <p>
-            Understanding the effectiveness of emergency response strategies requires
-            records about dispatch, calls for service, crime, budgets, staffing, and more.
+            Understanding the effectiveness of emergency response strategies
+            requires records about dispatch, calls for service, crime, budgets,
+            staffing, and more.
           </p>
         </div>
         <div>
@@ -307,8 +307,9 @@
             Studying Policy & Reform
           </h3>
           <p>
-            When a new emergency response strategy is developed, comparable records from 
-            different jurisdictions may be required to understand policy changes and their effects.
+            When a new emergency response strategy is developed, comparable
+            records from different jurisdictions may be required to understand
+            policy changes and their effects.
           </p>
         </div>
         <div>
@@ -317,16 +318,15 @@
             Performance & Outcome Analysis
           </h3>
           <p>
-            The outcomes of policing carry through to incarceration and prosecution.
-            A variety of consistent records over a longer time period are required to understand 
-            things like demographic disparities and recidivism.
+            The outcomes of policing carry through to incarceration and
+            prosecution. A variety of consistent records over a longer time
+            period are required to understand things like demographic
+            disparities and recidivism.
           </p>
         </div>
       </div>
       <div class="col-span-full">
-        <h2 class="my-0">
-          Examples
-        </h2>
+        <h2 class="my-0">Examples</h2>
       </div>
       <h3 class="col-span-full my-0">
         <FontAwesomeIcon :icon="faBook" class="text-brand-wine-300" />
@@ -456,9 +456,11 @@
             :icon="faArrowUpRightDots"
             class="pt-1.5 pr-3 text-brand-wine-100" />
           <span>
-            Grow our database, prioritizing locations followed by our users. 
-            To participate, <a href="https://airtable.com/appcYa6x4nS7W8IR3/shrk9c5sBsBr3cdJJ">
-            sign up for data labeling here!</a>
+            Grow our database, prioritizing locations followed by our users. To
+            participate,
+            <a href="https://airtable.com/appcYa6x4nS7W8IR3/shrk9c5sBsBr3cdJJ">
+              sign up for data labeling here!
+            </a>
           </span>
         </li>
       </ul>

--- a/src/pages/index.vue
+++ b/src/pages/index.vue
@@ -120,7 +120,9 @@
           evaluate local police systems and other crisis response programs.
         </p>
         <p>
-          All of our programs exist to help people answer questions with data.
+          All of our programs exist to help people answer questions big and
+          small about one of our most impactful local systems. Accessible data
+          is the first step.
           <strong>If you are starting a data project, we can help.</strong>
           <router-link
             class="pdap-button-primary mt-4"

--- a/src/pages/index.vue
+++ b/src/pages/index.vue
@@ -15,7 +15,7 @@
           class="mb-6"
           v-bind="{ ...mapData?.data }"
           @on-follow="(location_id) => followMutation.mutate(location_id)" />
-        </div>
+      </div>
     </section>
     <section class="col-span-full text-lg">
       <h2>About the data</h2>

--- a/src/pages/index.vue
+++ b/src/pages/index.vue
@@ -7,23 +7,26 @@
 <template>
   <main class="mb-24 grid grid-cols-3 max-w-5xl mx-auto @container w-full">
     <section class="col-span-full">
-      <h1>Explore data about police systems</h1>
+      <h1>Find data about police systems</h1>
+      <SearchForm />
+      <h2>Explore the map</h2>
       <DataSourceMap
         class="my-8 hidden md:block"
         v-bind="{ ...mapData?.data }"
         @on-follow="(location_id) => followMutation.mutate(location_id)" />
-      <SearchForm />
     </section>
     <section class="col-span-full text-lg">
       <h2>About the data</h2>
       <p>
-        We find and organize Data Sources (
+        Each
         <a
-          href="https://docs.pdap.io/activities/terms-and-definitions/what-is-a-data-source">
-          <i class="fa fa-question-circle" />
+          href="https://docs.pdap.io/about/terms-and-definitions/what-is-a-data-source">
+          "Data Source"
         </a>
-        ), places on the internet where public records may be found. Each one
-        describes one of the ~20,000 agencies we have indexed.
+        is a place on the internet where public records can be found about a
+        police system. Our database is community-maintained, with help from our
+        open-source apps. To help locate sources,
+        <a href="https://docs.pdap.io/">start with the docs!</a>
       </p>
       <p v-if="metricsData">
         Our database contains
@@ -279,7 +282,7 @@
         </p>
       </div>
       <div class="col-span-full pdap-grid-container grid-cols-2 text-lg">
-        <h2 class="my-0 col-span-full">Types of investigative projects</h2>
+        <h2 class="my-0 col-span-full">Data for investigative projects</h2>
         <div>
           <h3>
             <FontAwesomeIcon :icon="faEyeLowVision" />

--- a/src/pages/index.vue
+++ b/src/pages/index.vue
@@ -9,11 +9,13 @@
     <section class="col-span-full">
       <h1>Find data about police systems</h1>
       <SearchForm />
-      <h2>Explore the map</h2>
-      <DataSourceMap
-        class="my-8 hidden md:block"
-        v-bind="{ ...mapData?.data }"
-        @on-follow="(location_id) => followMutation.mutate(location_id)" />
+      <div class="hidden md:block">
+        <h2>Explore the map</h2>
+        <DataSourceMap
+          class="mb-6"
+          v-bind="{ ...mapData?.data }"
+          @on-follow="(location_id) => followMutation.mutate(location_id)" />
+        </div>
     </section>
     <section class="col-span-full text-lg">
       <h2>About the data</h2>


### PR DESCRIPTION
<!-- Title of PR should use a standard commit prefix (feat, fix, chore, docs, test, etc.) followed by an optional context ((components), (linting), etc), and a succinct description. I.E. `feat(components): add MyFancyComponent` or `fix(search/results): incomplete results displayed` -->

<!-- Does not have to match PR title. I.E. MyFancyComponent -->

<!-- What is the rationale for the changes? -->

## Description

- Makes yet more small language changes
- The map adds a bit to the load time, so I am loading it _after_ the search. 
- Doesn't show on mobile any more (see https://github.com/Police-Data-Accessibility-Project/pdap.io/issues/322)