### PR TITLE
feat: data request e2e

### DIFF
--- a/e2e/data-request/create.spec.js
+++ b/e2e/data-request/create.spec.js
@@ -1,0 +1,137 @@
+import { expect } from '@playwright/test';
+import { TEST_IDS } from '../fixtures/test-ids';
+import { PASSWORD_AUTH } from '../fixtures/users';
+import { test } from '../fixtures/base';
+
+import '../msw-setup.js';
+
+test.describe('Data Request Create Page', () => {
+  test.beforeEach(async ({ page }) => {
+    // Sign in before each test
+    await page.goto('/sign-in');
+    await page.fill('[name="email"]', PASSWORD_AUTH.email);
+    await page.fill('[name="password"]', PASSWORD_AUTH.password);
+    await page.click('button[type="submit"]');
+    await page.waitForLoadState('networkidle');
+  });
+
+  test('should display create data request form', async ({ page }) => {
+    await page.goto('/data-request/create');
+    await page.waitForLoadState('networkidle');
+
+    await expect(page.locator('h1')).toContainText('New request');
+    await expect(
+      page.locator(`[data-test="${TEST_IDS.data_request_create_form}"]`)
+    ).toBeVisible();
+    await expect(
+      page.locator(
+        `input[data-test="${TEST_IDS.data_request_create_title_input}"]`
+      )
+    ).toBeVisible();
+    await expect(
+      page.locator(`[data-test="${TEST_IDS.data_request_create_submit}"]`)
+    ).toBeVisible();
+  });
+
+  test('should require all form fields', async ({ page }) => {
+    await page.goto('/data-request/create');
+    await page.waitForLoadState('networkidle');
+
+    await page.click(`[data-test="${TEST_IDS.data_request_create_submit}"]`);
+    await expect(page.locator('.pdap-form-error-message')).toBeVisible();
+  });
+
+  test('should fill and submit complete form', async ({ page }) => {
+    await page.goto('/data-request/create');
+    await page.waitForLoadState('networkidle');
+
+    // Fill required fields
+    await page.fill(
+      `input[data-test="${TEST_IDS.data_request_create_title_input}"]`,
+      'Test Data Request'
+    );
+
+    // Add location
+    const typeaheadInput = page.locator(
+      `input[data-test="${TEST_IDS.data_request_create_location_input}"]`
+    );
+    await typeaheadInput.fill('Pittsburgh');
+    await page.waitForSelector(
+      `[data-test="${TEST_IDS.typeahead_list_item}"]`,
+      {
+        timeout: 5000
+      }
+    );
+    await page.click(
+      `[data-test="${TEST_IDS.typeahead_list_item}"]:first-child`
+    );
+
+    // Fill other required fields
+    await page.fill('input[name="coverage_range"]', '2020 - 2023');
+    await page.click('button:has-text("Select")');
+    await page.click('#input-request_urgency'); // TODO: test-ids?
+    await page.click('#request_urgency-option-urgent');
+    await page.fill('textarea[name="submission_notes"]', 'Test request notes');
+    await page.fill(
+      'textarea[name="data_requirements"]',
+      'Test data requirements'
+    );
+
+    await page.click(`[data-test="${TEST_IDS.data_request_create_submit}"]`);
+
+    await page.waitForResponse(
+      (response) =>
+        response.url().includes('/data-requests') &&
+        response.status() === 200 &&
+        response.request().method() === 'POST'
+    );
+  });
+
+  // TODO: add test for clearing to the /data-source/create route
+  test('should clear form when clear button clicked', async ({ page }) => {
+    await page.goto('/data-request/create');
+    await page.waitForLoadState('networkidle');
+
+    // Fill some fields
+    await page.fill(
+      `input[data-test="${TEST_IDS.data_request_create_title_input}"]`,
+      'Test Title'
+    );
+    await page.fill('textarea[name="submission_notes"]', 'Test notes');
+
+    // Click clear button
+    await page.click(`[data-test="${TEST_IDS.data_request_create_clear}"]`);
+
+    // Fields should be empty
+    await expect(
+      page.locator(
+        `input[data-test="${TEST_IDS.data_request_create_title_input}"]`
+      )
+    ).toHaveValue('');
+    await expect(page.locator('textarea[name="submission_notes"]')).toHaveValue(
+      ''
+    );
+  });
+
+  test('should validate location requirement', async ({ page }) => {
+    await page.goto('/data-request/create');
+    await page.waitForLoadState('networkidle');
+
+    // Fill all fields except location
+    await page.fill(
+      `input[data-test="${TEST_IDS.data_request_create_title_input}"]`,
+      'Test Request'
+    );
+    await page.fill('input[name="coverage_range"]', '2020 - 2023');
+    await page.click('button:has-text("Select")');
+    await page.click('#input-request_urgency'); // TODO: test-ids?
+    await page.click('#request_urgency-option-urgent');
+    await page.fill('textarea[name="submission_notes"]', 'Test notes');
+    await page.fill('textarea[name="data_requirements"]', 'Test requirements');
+
+    await page.click(`[data-test="${TEST_IDS.data_request_create_submit}"]`);
+
+    // Should show location error
+    await expect(page.locator('text=Please include a location')).toBeVisible();
+  });
+});

--- a/e2e/data-request/id.spec.js
+++ b/e2e/data-request/id.spec.js
@@ -1,0 +1,212 @@
+import { expect } from '@playwright/test';
+import { TEST_IDS } from '../fixtures/test-ids';
+import { test } from '../fixtures/base';
+
+import '../msw-setup.js';
+
+test.describe('Data Request Page', () => {
+  test('should display data request details', async ({ page }) => {
+    await page.goto('/data-request/1');
+    await page.waitForLoadState('networkidle');
+
+    // Should show data request title or not found message
+    const title = page.locator('h1');
+    await title.waitFor({ state: 'visible' });
+    await expect(title).toBeVisible();
+
+    // If data request exists, check for GitHub link
+    const githubLink = page.locator(
+      'a:has-text("Help out with this issue on GitHub")'
+    );
+    if (await githubLink.isVisible()) {
+      await expect(githubLink).toHaveAttribute('target', '_blank');
+    }
+  });
+
+  test('should show record type pills', async ({ page }) => {
+    await page.goto('/data-request/1');
+
+    // Wait for page to load
+    await page.waitForLoadState('networkidle');
+    await page.locator('h1').waitFor({ state: 'visible' });
+
+    // Should show record type pill if available
+    const recordTypePill = page.locator('.pill').first();
+    if (await recordTypePill.isVisible()) {
+      await expect(recordTypePill).toBeVisible();
+    }
+  });
+
+  test('should display all data request sections', async ({ page }) => {
+    await page.goto('/data-request/1');
+
+    await page.waitForLoadState('networkidle');
+    await page.locator('h1').waitFor({ state: 'visible' });
+
+    // Check for various sections
+    const sections = [
+      'Locations covered by request',
+      'Coverage Range',
+      'Target date',
+      'Request notes',
+      'Data requirements'
+    ];
+
+    for (const section of sections) {
+      const sectionHeader = page.locator(`h4:has-text("${section}")`);
+      if (await sectionHeader.isVisible()) {
+        await expect(sectionHeader).toBeVisible();
+      }
+    }
+  });
+
+  test('should show prev/next navigation when coming from search results', async ({
+    page
+  }) => {
+    // First go to search results to establish context
+    await page.goto('/search/results?location_id=6593');
+    await page.waitForLoadState('networkidle');
+
+    const dataRequestCount = await page
+      .locator(`[data-test="${TEST_IDS.data_request_link}"]`)
+      .count();
+    if (dataRequestCount === 0) {
+      return; // Skip test if no data requests available
+    }
+
+    // Click on a data request
+    await page.click(`[data-test="${TEST_IDS.data_request_link}"]`);
+
+    // Should be on data request page
+    await expect(page).toHaveURL(/\/data-request\/\d+/);
+
+    // Should show navigation if there are multiple results
+    const prevButton = page.locator('a:has-text("PREV")');
+    const nextButton = page.locator('a:has-text("NEXT")');
+
+    // At least one navigation button should be visible if there are multiple results
+    if ((await prevButton.isVisible()) || (await nextButton.isVisible())) {
+      // Test navigation functionality
+      if (
+        (await nextButton.isVisible()) &&
+        !(await nextButton.locator('.disabled').isVisible())
+      ) {
+        const currentUrl = page.url();
+        await nextButton.click();
+
+        // Should navigate to different data request
+        await expect(page).not.toHaveURL(currentUrl);
+        await expect(page).toHaveURL(/\/data-request\/\d+/);
+      }
+    }
+  });
+
+  test('should handle swipe navigation on mobile', async ({ page }) => {
+    await page.setViewportSize({ width: 375, height: 667 });
+
+    // Go through search results first
+    await page.goto('/search/results?location_id=6593');
+    await page.waitForLoadState('networkidle');
+
+    const dataRequestCount = await page
+      .locator(`[data-test="${TEST_IDS.data_request_link}"]`)
+      .count();
+    if (dataRequestCount === 0) {
+      return; // Skip test if no data requests available
+    }
+
+    await page.click(`[data-test="${TEST_IDS.data_request_link}"]`);
+
+    await expect(page).toHaveURL(/\/data-request\/\d+/);
+
+    // Test swipe gestures (simulated with mouse drag)
+    const main = page.locator('main');
+    if (await main.isVisible()) {
+      // Simulate swipe left (next) with mouse drag
+      await main.hover();
+      await page.mouse.down();
+      await page.mouse.move(50, 300);
+      await page.mouse.up();
+
+      // Should potentially navigate to next data request
+      await page.waitForTimeout(500);
+    }
+  });
+
+  test('should handle loading and error states', async ({ page }) => {
+    // Test loading state
+    const responsePromise = page.waitForResponse(/\/data-requests\/\d+/);
+    await page.goto('/data-request/1');
+
+    // Should show loading spinner initially
+    const spinner = page.locator('.pdap-spinner'); // TODO - why data-test not forwarded to spinner?
+    if (await spinner.isVisible({ timeout: 1000 })) {
+      await expect(spinner).toBeVisible();
+    }
+
+    await responsePromise;
+    await page.waitForLoadState('networkidle');
+
+    // Should show content after loading
+    await page.locator('h1').waitFor({ state: 'visible' });
+    await expect(page.locator('h1')).toBeVisible();
+  });
+
+  test('should handle non-existent data request', async ({ page }) => {
+    await page.goto('/data-request/99999');
+    await page.waitForLoadState('networkidle');
+
+    // Should show not found message
+    await page
+      .locator('h1:has-text("Data request not found")')
+      .waitFor({ state: 'visible' });
+    await expect(
+      page.locator('h1:has-text("Data request not found")')
+    ).toBeVisible();
+    await expect(
+      page.locator('p:has-text("We don\'t have a record of that request")')
+    ).toBeVisible();
+  });
+
+  test('should display location information correctly', async ({ page }) => {
+    await page.goto('/data-request/1');
+
+    await page.waitForLoadState('networkidle');
+    await page.locator('h1').waitFor({ state: 'visible' });
+
+    // Check if location information is displayed
+    const locationSection = page.locator(
+      'h4:has-text("Locations covered by request")'
+    );
+    if (await locationSection.isVisible()) {
+      await expect(locationSection).toBeVisible();
+
+      // Should have location text following the section
+      const locationText = page.locator(
+        'h4:has-text("Locations covered by request") + p'
+      );
+      if (await locationText.isVisible()) {
+        await expect(locationText).toBeVisible();
+      }
+    }
+  });
+
+  test('should display urgency and coverage information', async ({ page }) => {
+    await page.goto('/data-request/1');
+
+    await page.waitForLoadState('networkidle');
+    await page.locator('h1').waitFor({ state: 'visible' });
+
+    // Check coverage range section
+    const coverageSection = page.locator('h4:has-text("Coverage Range")');
+    if (await coverageSection.isVisible()) {
+      await expect(coverageSection).toBeVisible();
+    }
+
+    // Check target date section
+    const targetSection = page.locator('h4:has-text("Target date")');
+    if (await targetSection.isVisible()) {
+      await expect(targetSection).toBeVisible();
+    }
+  });
+});

--- a/e2e/fixtures/test-ids.js
+++ b/e2e/fixtures/test-ids.js
@@ -66,5 +66,13 @@ export const TEST_IDS = {
   data_source_create_description_input: 'data-source-create-description-input',
   data_source_create_submit: 'data-source-create-submit',
   data_source_create_clear: 'data-source-create-clear',
-  data_source_create_advanced: 'data-source-create-advanced'
+  data_source_create_advanced: 'data-source-create-advanced',
+
+  // Data Request Pages
+  data_request_link: 'data-request-link',
+  data_request_create_form: 'data-request-create-form',
+  data_request_create_title_input: 'data-request-create-title-input',
+  data_request_create_location_input: 'data-request-create-location-input',
+  data_request_create_submit: 'data-request-create-submit',
+  data_request_create_clear: 'data-request-create-clear'
 };

--- a/src/pages/data-request/[id].vue
+++ b/src/pages/data-request/[id].vue
@@ -14,7 +14,7 @@
         <Spinner
           :show="dataRequestsPending"
           :size="64"
-          text="Fetching data source results..." />
+          text="Fetching data request..." />
       </div>
 
       <div
@@ -28,8 +28,8 @@
 
         <!-- TODO: not found UI - do we want to send the user to search or something? -->
         <template v-else-if="!error && !dataRequest">
-          <h1>Data source not found</h1>
-          <p>We don't have a record of that source.</p>
+          <h1>Data request not found</h1>
+          <p>We don't have a record of that request.</p>
         </template>
         <!-- For each section, render details -->
         <template v-else>
@@ -71,8 +71,9 @@
             v-if="dataRequest.github_issue_url"
             :href="dataRequest.github_issue_url"
             class="pdap-button-primary mt-2 mb-4"
-            _target="blank"
-            rel="noreferrer">
+            target="_blank"
+            rel="noreferrer"
+            data-test="data-request-github-link">
             Help out with this issue on GitHub
             <FontAwesomeIcon :icon="faLink" />
           </a>
@@ -108,14 +109,14 @@ const queryKey = computed(() => [DATA_REQUEST, reactiveParams.value.id]);
 const {
   isLoading: dataRequestsPending,
   data: dataRequest,
-  error
+  error: dataSourceError
 } = useQuery({
   queryKey,
   queryFn: async () => {
     const response = await getDataRequest(route.params.id);
     return response.data.data;
   },
-  staleTime: 5 * 60 * 1000 // 5 minutes,
+  staleTime: 5 * 60 * 1000 // 5 minutes
 });
 
 const currentIdIndex = computed(() =>
@@ -135,6 +136,11 @@ const showExpandDescriptionButton = ref(false);
 const descriptionRef = ref();
 const mainRef = ref();
 const navIs = ref('');
+const error = computed(() =>
+  dataSourceError.value?.message?.includes('not found')
+    ? dataSourceError.value
+    : null
+);
 
 // Handle swipe
 const { direction } = useSwipe(mainRef, {

--- a/src/pages/data-request/create.vue
+++ b/src/pages/data-request/create.vue
@@ -17,13 +17,15 @@
       class="grid md:grid-cols-2 gap-x-4 gap-y-2 [&>.pdap-form-error-message]:md:col-span-2"
       name="new-request"
       :schema="SCHEMA"
+      data-test="data-request-create-form"
       @error="error"
       @submit="submit">
       <InputText
         :id="'input-' + INPUT_NAMES.title"
         class="md:col-span-2"
         :name="INPUT_NAMES.title"
-        placeholder="Briefly describe the general purpose or topic.">
+        placeholder="Briefly describe the general purpose or topic."
+        data-test="data-request-create-title-input">
         <template #label>
           <h4>Request title</h4>
         </template>
@@ -60,6 +62,7 @@
         :placeholder="
           selectedLocations.length ? 'Enter another place' : 'Enter a place'
         "
+        data-test="data-request-create-location-input"
         @select-item="
           (item) => {
             if (item) {
@@ -143,13 +146,15 @@
           :is-loading="createRequestMutation.isLoading"
           class="min-w-52"
           intent="primary"
-          type="submit">
+          type="submit"
+          data-test="data-request-create-submit">
           Submit request
         </Button>
         <Button
           :disabled="createRequestMutation.isLoading"
           intent="secondary"
           type="button"
+          data-test="data-request-create-clear"
           @click="clear">
           Clear
         </Button>


### PR DESCRIPTION
<!-- Title of PR should use a standard commit prefix (feat, fix, chore, docs, test, etc.) followed by an optional context ((components), (linting), etc), and a succinct description. I.E. `feat(components): add MyFancyComponent` or `fix(search/results): incomplete results displayed` -->

<!-- Does not have to match PR title. I.E. MyFancyComponent -->

# e2e for data request routes

<!-- What is the rationale for the changes? -->

## Background

#203 
#224 

<!-- What is the description of the changes? -->

## Description

- e2e tests for /data-request/create and /data-request/:id

## Acceptance Criteria

<!-- What are the steps to test the changes? -->

1. Pull branch, run `npm run test:e2e`, or
2. view this successful run
