### PR TITLE
feat: aggregated sources in sidebar

### DIFF
--- a/src/components/maps/DataSourceMapSidebar.vue
+++ b/src/components/maps/DataSourceMapSidebar.vue
@@ -97,9 +97,11 @@
           @click="toggleAggregatedSection"
         >
           <div class="flex flex-col gap-1">
-            <span class="text-xs font-semibold uppercase tracking-wide text-wineneutral-500"
-              >Aggregated sources</span
+            <span
+              class="text-xs font-semibold uppercase tracking-wide text-wineneutral-500"
             >
+              Aggregated sources
+            </span>
             <span class="text-lg font-semibold text-wineneutral-900">
               {{ headerTitle }}
             </span>
@@ -164,7 +166,9 @@
                         <FontAwesomeIcon :icon="faArrowUpRightFromSquare" />
                       </a>
                       <router-link
-                        v-if="(source.id ?? source.source_id)?.toString().trim()"
+                        v-if="
+                          (source.id ?? source.source_id)?.toString().trim()
+                        "
                         :to="`/data-source/${source.id ?? source.source_id}`"
                         class="flex gap-2 items-center flex-initial px-1 py-0.5 rounded-sm text-goldneutral-950 bg-goldneutral-100 dark:text-wineneutral-950 dark:bg-goldneutral-100"
                         @click.stop


### PR DESCRIPTION
<!-- Title of PR should use a standard commit prefix (feat, fix, chore, docs, test, etc.) followed by an optional context ((components), (linting), etc), and a succinct description. I.E. `feat(components): add MyFancyComponent` or `fix(search/results): incomplete results displayed` -->

<!-- Does not have to match PR title. I.E. MyFancyComponent -->

# Aggregated sources in map sidebar

<!-- What is the rationale for the changes? -->

## Background

- #363

<!-- What is the description of the changes? -->

## Description

- Adds aggregated sources to map sidebar

https://github.com/user-attachments/assets/3a80f1fa-c4e4-475c-9a25-7d1e27597f80


## Testing

- [x] End-to-end tests are up to date with these changes

## Acceptance Criteria

<!-- What are the steps to test the changes? -->

1. Run app, ensure aggregated sources appear in a dropdown when you select a location
