### PR TITLE
Redesign annotate page with improved layout and mobile support

### DIFF
--- a/src/pages/annotate/_components/Confirm.vue
+++ b/src/pages/annotate/_components/Confirm.vue
@@ -1,41 +1,54 @@
 <template>
-  <transition mode="out-in" :name="navIs">
+  <transition mode="out-in">
     <div
       v-if="submitPending"
-      class="flex items-center justify-center h-[80vh] w-full flex-col relative"
+      class="flex items-center justify-center min-h-[300px] w-full flex-col relative"
     >
-      <!--TODO: Spinner does not currently display on submission. Unclear why.-->
       <Spinner
         :show="submitPending"
         :size="64"
         text="Submitting annotation..."
       />
     </div>
-    <div
-      v-else
-      class="flex flex-col sm:flex-row sm:flex-wrap mt-6 sm:items-stretch sm:justify-between gap-4 h-full w-full relative [&>*]:w-full"
-    >
-      <p>
-        <b>URL Type</b>
-        : {{ props.urlType?.display_name }}
-      </p>
-      <p>
-        <b>Location</b>
-        : {{ props.location?.display_name }}
-      </p>
-      <p>
-        <b>Agency</b>
-        : {{ props.agency?.display_name }}
-      </p>
-      <p>
-        <b>RecordType</b>
-        : {{ props.recordType }}
-      </p>
-      <p>
-        <b>Name</b>
-        : {{ props.name?.name }}
-      </p>
-      <button @click="handleSubmit" class="pdap-button-primary">Submit</button>
+    <div v-else>
+      <h3 class="confirm-heading">Review your annotation</h3>
+
+      <div class="confirm-summary">
+        <div class="confirm-row">
+          <span class="confirm-label">URL Type</span>
+          <span class="confirm-value">
+            {{ props.urlType?.display_name || '—' }}
+          </span>
+        </div>
+        <div class="confirm-row">
+          <span class="confirm-label">Location</span>
+          <span class="confirm-value">
+            {{ props.location?.display_name || '—' }}
+          </span>
+        </div>
+        <div class="confirm-row">
+          <span class="confirm-label">Agency</span>
+          <span class="confirm-value">
+            {{ props.agency?.display_name || '—' }}
+          </span>
+        </div>
+        <div class="confirm-row">
+          <span class="confirm-label">Record Type</span>
+          <span class="confirm-value">
+            {{ props.recordType || '—' }}
+          </span>
+        </div>
+        <div class="confirm-row confirm-row--last">
+          <span class="confirm-label">Name</span>
+          <span class="confirm-value">
+            {{ props.name?.name || '—' }}
+          </span>
+        </div>
+      </div>
+
+      <button @click="handleSubmit" class="confirm-submit">
+        Submit Annotation
+      </button>
     </div>
   </transition>
 </template>
@@ -141,3 +154,34 @@ async function handleSubmit() {
   emit('submit');
 }
 </script>
+
+<style scoped>
+.confirm-heading {
+  @apply text-sm font-semibold text-wineneutral-600 uppercase tracking-wider mb-4;
+}
+
+.confirm-summary {
+  @apply rounded-lg border border-wineneutral-200 overflow-hidden;
+}
+
+.confirm-row {
+  @apply flex items-baseline justify-between px-4 py-3 border-b border-wineneutral-100;
+}
+
+.confirm-row--last {
+  @apply border-b-0;
+}
+
+.confirm-label {
+  @apply text-sm font-semibold text-wineneutral-600 shrink-0;
+}
+
+.confirm-value {
+  @apply text-sm text-wineneutral-900 text-right;
+}
+
+.confirm-submit {
+  @apply mt-6 w-full py-3 rounded-lg bg-brand-gold-500 text-white font-bold text-sm
+    transition-colors hover:bg-brand-gold-600 active:bg-brand-gold-700;
+}
+</style>

--- a/src/pages/annotate/_components/RecordType.vue
+++ b/src/pages/annotate/_components/RecordType.vue
@@ -162,11 +162,11 @@ function handleRadioFormSelect(option: RadioOption) {
 }
 
 .rt-option--selected {
-  @apply bg-brand-gold-600 text-white border-brand-gold-600 font-semibold;
+  @apply bg-brand-wine-600 text-white border-brand-wine-600 font-semibold;
 }
 
 .rt-option--selected:hover {
-  @apply bg-brand-gold-700 border-brand-gold-700;
+  @apply bg-brand-wine-700 border-brand-wine-700;
 }
 
 .rt-option-text {

--- a/src/pages/annotate/_components/RecordType.vue
+++ b/src/pages/annotate/_components/RecordType.vue
@@ -1,62 +1,55 @@
 <template>
   <div>
-    <label class="block text-sm font-medium mb-1">Record type</label>
+    <h3 class="rt-heading">Select a record type</h3>
 
-    <div class="grid grid-cols-1 gap-4">
-      <p>Record Type: {{ selectedRecordTypeModel }}</p>
-      <div class="col-auto">
-        <RadioForm
-          v-model="selectedRadioRecordType"
-          :options="radioOptions"
-          header="Suggestions"
-          @update:model-value="handleRadioFormSelect"
-        />
-      </div>
+    <!-- Suggestions -->
+    <div v-if="radioOptions.length" class="rt-suggestions">
+      <RadioForm
+        v-model="selectedRadioRecordType"
+        :options="radioOptions"
+        header="Suggestions"
+        @update:model-value="handleRadioFormSelect"
+      />
     </div>
 
-    <br />
-    <!-- Select for Record Type -->
+    <!-- All record types by category -->
+    <div class="rt-categories">
+      <fieldset
+        v-for="(types, categoryName) in RECORD_TYPES_BY_CATEGORY"
+        :key="categoryName"
+        class="rt-category"
+      >
+        <legend class="rt-category-legend">
+          {{ categoryName }}
+        </legend>
 
-    <form id="id" name="name" class="pdap-form">
-      <div class="space-y-6 pdap-input-radio-group">
-        <fieldset
-          v-for="(types, categoryName) in RECORD_TYPES_BY_CATEGORY"
-          :key="categoryName"
-          class="rounded border p-3"
-        >
-          <legend class="px-1 font-semibold">
-            {{ categoryName }}
-          </legend>
+        <div class="rt-options">
+          <label
+            v-for="type in types"
+            :key="type"
+            :for="type"
+            class="rt-option"
+            :class="{
+              'rt-option--selected': selectedRecordTypeModel === type
+            }"
+          >
+            <input
+              :id="type"
+              type="radio"
+              name="record-type"
+              :value="type"
+              v-model="selectedRecordTypeModel"
+              class="sr-only"
+              @change="handleSelectChange"
+            />
+            <span class="rt-option-text">{{ type }}</span>
+          </label>
+        </div>
+      </fieldset>
+    </div>
 
-          <div class="mt-2 grid grid-cols-3 gap-2">
-            <div
-              class="pdap-input pdap-input-radio"
-              v-for="type in types"
-              :key="type"
-            >
-              <input
-                :id="type"
-                type="radio"
-                name="record-type"
-                :value="type"
-                v-model="selectedRecordTypeModel"
-                @change="handleSelectChange"
-              />
-
-              <label
-                :for="type"
-                class="flex items-center gap-2 rounded px-2 py-1 hover:bg-brand-wine-600 cursor-pointer"
-              >
-                <span>{{ type }}</span>
-              </label>
-            </div>
-          </div>
-        </fieldset>
-      </div>
-    </form>
-
-    <p class="mt-2 text-sm text-gray-600">
-      Selected: {{ selectedRecordTypeModel || 'none' }}
+    <p v-if="selectedRecordTypeModel" class="rt-selected">
+      Selected: <strong>{{ selectedRecordTypeModel }}</strong>
     </p>
   </div>
 </template>
@@ -134,3 +127,53 @@ function handleRadioFormSelect(option: RadioOption) {
   emit('select', null);
 }
 </script>
+
+<style scoped>
+.rt-heading {
+  @apply text-sm font-semibold text-wineneutral-600 uppercase tracking-wider mb-4;
+}
+
+.rt-suggestions {
+  @apply mb-5 pb-5 border-b border-wineneutral-200;
+}
+
+.rt-categories {
+  @apply space-y-4;
+}
+
+.rt-category {
+  @apply rounded-lg border border-wineneutral-200 p-3;
+}
+
+.rt-category-legend {
+  @apply px-2 text-sm font-bold text-wineneutral-700;
+}
+
+.rt-options {
+  @apply mt-2 grid grid-cols-2 sm:grid-cols-3 gap-1.5;
+}
+
+.rt-option {
+  @apply flex items-center gap-2 rounded-md px-2.5 py-1.5 text-sm cursor-pointer transition-colors border border-transparent;
+}
+
+.rt-option:hover {
+  @apply bg-wineneutral-100 border-wineneutral-200;
+}
+
+.rt-option--selected {
+  @apply bg-brand-wine-600 text-white border-brand-wine-600 font-semibold;
+}
+
+.rt-option--selected:hover {
+  @apply bg-brand-wine-700 border-brand-wine-700;
+}
+
+.rt-option-text {
+  @apply leading-tight;
+}
+
+.rt-selected {
+  @apply mt-4 text-sm text-wineneutral-600 bg-wineneutral-50 rounded-lg px-3 py-2 border border-wineneutral-200;
+}
+</style>

--- a/src/pages/annotate/_components/RecordType.vue
+++ b/src/pages/annotate/_components/RecordType.vue
@@ -162,11 +162,11 @@ function handleRadioFormSelect(option: RadioOption) {
 }
 
 .rt-option--selected {
-  @apply bg-brand-wine-600 text-white border-brand-wine-600 font-semibold;
+  @apply bg-amber-600 text-white border-amber-600 font-semibold;
 }
 
 .rt-option--selected:hover {
-  @apply bg-brand-wine-700 border-brand-wine-700;
+  @apply bg-amber-700 border-amber-700;
 }
 
 .rt-option-text {

--- a/src/pages/annotate/_components/RecordType.vue
+++ b/src/pages/annotate/_components/RecordType.vue
@@ -162,11 +162,11 @@ function handleRadioFormSelect(option: RadioOption) {
 }
 
 .rt-option--selected {
-  @apply bg-amber-600 text-white border-amber-600 font-semibold;
+  @apply bg-brand-gold-600 text-white border-brand-gold-600 font-semibold;
 }
 
 .rt-option--selected:hover {
-  @apply bg-amber-700 border-amber-700;
+  @apply bg-brand-gold-700 border-brand-gold-700;
 }
 
 .rt-option-text {

--- a/src/pages/annotate/_components/RecordType.vue
+++ b/src/pages/annotate/_components/RecordType.vue
@@ -150,7 +150,7 @@ function handleRadioFormSelect(option: RadioOption) {
 }
 
 .rt-options {
-  @apply mt-2 grid grid-cols-2 sm:grid-cols-3 gap-1.5;
+  @apply mt-2 grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-1.5;
 }
 
 .rt-option {

--- a/src/pages/annotate/_components/URLType.vue
+++ b/src/pages/annotate/_components/URLType.vue
@@ -166,8 +166,8 @@ function getAnnotationSuggestionValues(ut: UrlType): AnnoLabels {
 }
 
 .urltype-card--selected {
-  @apply border-brand-wine-500 bg-brand-wine-600 text-white;
-  box-shadow: 0 0 0 1px var(--color-brand-wine-500);
+  @apply border-amber-500 bg-amber-600 text-white;
+  box-shadow: 0 0 0 1px rgb(245 158 11);
 }
 
 .urltype-card-body {

--- a/src/pages/annotate/_components/URLType.vue
+++ b/src/pages/annotate/_components/URLType.vue
@@ -166,8 +166,8 @@ function getAnnotationSuggestionValues(ut: UrlType): AnnoLabels {
 }
 
 .urltype-card--selected {
-  @apply border-amber-500 bg-amber-600 text-white;
-  box-shadow: 0 0 0 1px rgb(245 158 11);
+  @apply border-brand-gold-500 bg-brand-gold-600 text-white;
+  box-shadow: 0 0 0 1px rgb(213 162 60);
 }
 
 .urltype-card-body {

--- a/src/pages/annotate/_components/URLType.vue
+++ b/src/pages/annotate/_components/URLType.vue
@@ -1,20 +1,32 @@
 <template>
-  <div class="grid grid-cols-1 gap-4 md:grid-cols-3 md:grid-rows-2">
-    <div
-      v-for="option in formattedOptions"
-      :key="option.value"
-      class="p-4 cursor-pointer rounded-lg border transition"
-      :class="handleOuterBlockClass(option.value)"
-      @click="handleSelectOption(option.value)"
-    >
-      <div class="rounded-lg p-4" :class="handleInnerBlockClass(option.value)">
-        <p>{{ option.value }}</p>
-        <p class="text-sm">{{ descriptionMapping[option.value] }}</p>
-      </div>
+  <div>
+    <h3 class="urltype-heading">What type of page is this?</h3>
+    <div class="urltype-grid">
+      <button
+        v-for="option in formattedOptions"
+        :key="option.value"
+        type="button"
+        class="urltype-card"
+        :class="
+          props.modelValue?.display_name === option.value
+            ? 'urltype-card--selected'
+            : 'urltype-card--default'
+        "
+        @click="handleSelectOption(option.value)"
+      >
+        <div class="urltype-card-body">
+          <span class="urltype-card-title">{{ option.value }}</span>
+          <span class="urltype-card-desc">
+            {{ descriptionMapping[option.value] }}
+          </span>
+        </div>
 
-      <div class="mt-2">
-        <AnnotationSpan :labels="option.annoLabels" />
-      </div>
+        <AnnotationSpan
+          v-if="option.annoLabels?.user || option.annoLabels?.robo"
+          :labels="option.annoLabels"
+          class="mt-2"
+        />
+      </button>
     </div>
   </div>
 </template>
@@ -85,7 +97,7 @@ const urlTypeMapping = {
 const descriptionMapping = {
   [urlTypes.DATA_SOURCE]: 'Public records about police systems',
   [urlTypes.META_URL]:
-    "An relevant agency's landing page, or info about the agency.",
+    "A relevant agency's landing page, or info about the agency.",
   [urlTypes.NOT_RELEVANT]: 'Not a data source or meta URL',
   [urlTypes.INDIVIDUAL]:
     'An individual record where a list of records is available.',
@@ -98,7 +110,7 @@ const descriptionMapping = {
 //====================
 const suggestionMap = computed<Record<UrlType, number>>(() => {
   return Object.fromEntries(
-    props.suggestions.map((s) => [s.url_type, s.endorsement_count]) // or transform however you want
+    props.suggestions.map((s) => [s.url_type, s.endorsement_count])
   );
 });
 
@@ -120,20 +132,6 @@ function handleSelectOption(option: string) {
   emit('select', null);
 }
 
-function handleInnerBlockClass(option: string): string {
-  if (props.modelValue?.display_name == option) {
-    return 'bg-wineneutral-700 text-black font-bold';
-  }
-  return 'bg-black text-white';
-}
-
-function handleOuterBlockClass(option: string): string {
-  if (props.modelValue?.display_name == option) {
-    return 'bg-wineneutral-300 border-wineneutral-500 hover:border-amber-800';
-  }
-  return 'bg-wineneutral-50 border-transparent hover:border-amber-800';
-}
-
 //====================
 //     Helpers
 //====================
@@ -149,3 +147,46 @@ function getAnnotationSuggestionValues(ut: UrlType): AnnoLabels {
   };
 }
 </script>
+
+<style scoped>
+.urltype-heading {
+  @apply text-sm font-semibold text-wineneutral-600 uppercase tracking-wider mb-4;
+}
+
+.urltype-grid {
+  @apply grid grid-cols-1 sm:grid-cols-2 gap-3;
+}
+
+.urltype-card {
+  @apply text-left rounded-lg border-2 p-4 transition-all duration-150 cursor-pointer w-full;
+}
+
+.urltype-card--default {
+  @apply border-wineneutral-200 bg-wineneutral-50 hover:border-brand-wine-300 hover:bg-wineneutral-100;
+}
+
+.urltype-card--selected {
+  @apply border-brand-wine-500 bg-brand-wine-600 text-white;
+  box-shadow: 0 0 0 1px var(--color-brand-wine-500);
+}
+
+.urltype-card-body {
+  @apply flex flex-col gap-1;
+}
+
+.urltype-card-title {
+  @apply font-bold text-sm;
+}
+
+.urltype-card-desc {
+  @apply text-xs leading-relaxed;
+}
+
+.urltype-card--default .urltype-card-desc {
+  @apply text-wineneutral-500;
+}
+
+.urltype-card--selected .urltype-card-desc {
+  @apply text-white/80;
+}
+</style>

--- a/src/pages/annotate/_components/URLType.vue
+++ b/src/pages/annotate/_components/URLType.vue
@@ -166,8 +166,8 @@ function getAnnotationSuggestionValues(ut: UrlType): AnnoLabels {
 }
 
 .urltype-card--selected {
-  @apply border-brand-gold-500 bg-brand-gold-600 text-white;
-  box-shadow: 0 0 0 1px rgb(213 162 60);
+  @apply border-brand-wine-500 bg-brand-wine-600 text-white;
+  box-shadow: 0 0 0 1px rgb(81 42 79);
 }
 
 .urltype-card-body {

--- a/src/pages/annotate/_components/URLType.vue
+++ b/src/pages/annotate/_components/URLType.vue
@@ -154,11 +154,11 @@ function getAnnotationSuggestionValues(ut: UrlType): AnnoLabels {
 }
 
 .urltype-grid {
-  @apply grid grid-cols-1 sm:grid-cols-2 gap-3;
+  @apply grid grid-cols-1 sm:grid-cols-2 gap-2 sm:gap-3;
 }
 
 .urltype-card {
-  @apply text-left rounded-lg border-2 p-4 transition-all duration-150 cursor-pointer w-full;
+  @apply text-left rounded-lg border-2 p-3 sm:p-4 transition-all duration-150 cursor-pointer w-full;
 }
 
 .urltype-card--default {

--- a/src/pages/annotate/_components/_agency/Agency.vue
+++ b/src/pages/annotate/_components/_agency/Agency.vue
@@ -120,7 +120,7 @@ function handleAgencySelect(ag: AgencyLocationSelection | null) {
 }
 
 .view-current {
-  @apply mb-4 text-sm bg-brand-wine-50 border border-brand-wine-200 rounded-lg px-3 py-2;
+  @apply mb-4 text-sm bg-amber-900/20 border border-amber-600 rounded-lg px-3 py-2 text-amber-100;
 }
 
 .view-current-label {

--- a/src/pages/annotate/_components/_agency/Agency.vue
+++ b/src/pages/annotate/_components/_agency/Agency.vue
@@ -1,18 +1,25 @@
 <template>
   <div>
-    <p>Agency: {{ agencyModel?.display_name }}</p>
-    <p>Agency ID: {{ agencyModel?.id }}</p>
-    <div class="grid grid-cols-1 gap-4">
-      <div class="col-auto">
-        <RadioForm
-          v-model="selectedRadioAgency"
-          :options="radioOptions"
-          header="Suggestions"
-          @update:model-value="handleRadioFormSelect"
-        />
-      </div>
+    <h3 class="view-heading">Select an agency</h3>
+
+    <div v-if="agencyModel" class="view-current">
+      <span class="view-current-label">Selected:</span>
+      <strong>{{ agencyModel.display_name }}</strong>
     </div>
-    <SearchForm @update:model-value="handleAgencySelect" />
+
+    <div v-if="radioOptions.length" class="view-suggestions">
+      <RadioForm
+        v-model="selectedRadioAgency"
+        :options="radioOptions"
+        header="Suggestions"
+        @update:model-value="handleRadioFormSelect"
+      />
+    </div>
+
+    <div class="view-search">
+      <h4 class="view-search-label">Or search for an agency</h4>
+      <SearchForm @update:model-value="handleAgencySelect" />
+    </div>
   </div>
 </template>
 
@@ -91,7 +98,7 @@ watch(resetKey, () => {
 //===================
 function handleRadioFormSelect(option: RadioOption) {
   agencyModel.value = {
-    id: Number(option.value), // option.value is typed as String | Number
+    id: Number(option.value),
     display_name: option.display_name
   };
   emit('select', null);
@@ -106,3 +113,29 @@ function handleAgencySelect(ag: AgencyLocationSelection | null) {
   emit('select', null);
 }
 </script>
+
+<style scoped>
+.view-heading {
+  @apply text-sm font-semibold text-wineneutral-600 uppercase tracking-wider mb-4;
+}
+
+.view-current {
+  @apply mb-4 text-sm bg-brand-wine-50 border border-brand-wine-200 rounded-lg px-3 py-2;
+}
+
+.view-current-label {
+  @apply text-wineneutral-500 mr-1;
+}
+
+.view-suggestions {
+  @apply mb-5 pb-5 border-b border-wineneutral-200;
+}
+
+.view-search {
+  @apply mt-2;
+}
+
+.view-search-label {
+  @apply text-xs font-bold text-wineneutral-500 uppercase tracking-wider mb-2;
+}
+</style>

--- a/src/pages/annotate/_components/_agency/Agency.vue
+++ b/src/pages/annotate/_components/_agency/Agency.vue
@@ -120,7 +120,7 @@ function handleAgencySelect(ag: AgencyLocationSelection | null) {
 }
 
 .view-current {
-  @apply mb-4 text-sm bg-amber-900/20 border border-amber-600 rounded-lg px-3 py-2 text-amber-100;
+  @apply mb-4 text-sm bg-goldneutral-900/20 border border-goldneutral-600 rounded-lg px-3 py-2 text-goldneutral-100;
 }
 
 .view-current-label {

--- a/src/pages/annotate/_components/_agency/SearchAgencyForm.vue
+++ b/src/pages/annotate/_components/_agency/SearchAgencyForm.vue
@@ -1,57 +1,43 @@
 <template>
-  <div class="px-4 mb-4 border-wineneutral-300 bg-wineneutral-50 border-2">
-    <div
-      class="col-span-1 flex flex-col mt-4 gap-4 @md:col-span-2 @lg:col-span-3 @md:flex-row @md:gap-0"
+  <div class="search-form">
+    <Typeahead
+      id="agencies"
+      ref="typeaheadRef"
+      :error="typeaheadError"
+      :format-item-for-display="formatText"
+      :items="items"
+      placeholder="Enter an agency"
+      @select-item="handleSelectRecord"
+      @on-input="fetchTypeaheadResults"
     >
-      <Typeahead
-        id="agencies"
-        ref="typeaheadRef"
-        class="md:col-span-2"
-        :error="typeaheadError"
-        :format-item-for-display="formatText"
-        :items="items"
-        placeholder="Enter an agency"
-        @select-item="handleSelectRecord"
-        @on-input="fetchTypeaheadResults"
-      >
-        <!-- Item to render passed as scoped slot -->
-        <template #item="item">
-          <!-- eslint-disable-next-line vue/no-v-html This data is coming from our API, so we can trust it-->
-          <span v-html="typeaheadRef?.boldMatchText(formatText(item))" />
-        </template>
+      <!-- Item to render passed as scoped slot -->
+      <template #item="item">
+        <!-- eslint-disable-next-line vue/no-v-html This data is coming from our API, so we can trust it-->
+        <span v-html="typeaheadRef?.boldMatchText(formatText(item))" />
+      </template>
 
-        <template #not-found>
-          <span>
-            <Button
-              class="text-left p-0"
-              intent="tertiary"
-              type="button"
-              @click="
-                () => {
-                  agencyNotAvailable = typeaheadRef.value;
-                  items = [];
-                  typeaheadRef.clearInput();
-                }
-              "
-            >
-              <strong>No results found.</strong>
-              Would you like to suggest
-              {{ typeaheadRef.value }}
-              be added to our agencies database?
-            </Button>
-          </span>
-        </template>
-      </Typeahead>
-      <!--TODO: This is a hacky fix to account for the fact that, without these, the suggestions disappear from the div-->
-      <br />
-      <br />
-      <br />
-      <br />
-      <br />
-      <br />
-      <br />
-      <br />
-    </div>
+      <template #not-found>
+        <span>
+          <Button
+            class="text-left p-0"
+            intent="tertiary"
+            type="button"
+            @click="
+              () => {
+                agencyNotAvailable = typeaheadRef.value;
+                items = [];
+                typeaheadRef.clearInput();
+              }
+            "
+          >
+            <strong>No results found.</strong>
+            Would you like to suggest
+            {{ typeaheadRef.value }}
+            be added to our agencies database?
+          </Button>
+        </span>
+      </template>
+    </Typeahead>
   </div>
 </template>
 
@@ -132,3 +118,9 @@ function handleSelectRecord(item) {
   emit('update:modelValue', item);
 }
 </script>
+
+<style scoped>
+.search-form {
+  @apply rounded-lg border border-wineneutral-200 bg-wineneutral-50 p-4 min-h-[200px];
+}
+</style>

--- a/src/pages/annotate/_components/_header/Header.vue
+++ b/src/pages/annotate/_components/_header/Header.vue
@@ -1,20 +1,22 @@
 <template>
-  <div v-if="requestPending">
-    <Spinner
-      :show="requestPending"
-      :size="64"
-      text="Fetching user contributions..."
-    />
-  </div>
-  <div class="overflow-x-auto">
-    <span v-if="userContributions">
-      <strong>URLs Annotated:</strong>
-      {{ userContributions.count_validated }}
-    </span>
-    <strong>URL ID:</strong>
-    {{ props.urlID }}
-    <strong>Page Title:</strong>
-    {{ props.pageTitle }}
+  <div class="header-info">
+    <div v-if="requestPending" class="header-loading">
+      <Spinner :show="requestPending" :size="20" text="" />
+      <span class="text-xs text-wineneutral-400">Loading stats...</span>
+    </div>
+    <template v-else>
+      <div v-if="userContributions" class="header-stat">
+        <span class="header-stat-label">Annotated</span>
+        <span class="header-stat-value">{{
+          userContributions.count_validated
+        }}</span>
+      </div>
+    </template>
+
+    <div v-if="props.pageTitle" class="header-title">
+      <span class="header-stat-label">Page</span>
+      <span class="header-title-text">{{ props.pageTitle }}</span>
+    </div>
   </div>
 </template>
 
@@ -61,3 +63,33 @@ const {
   }
 });
 </script>
+
+<style scoped>
+.header-info {
+  @apply flex flex-col gap-2 text-sm;
+}
+
+.header-loading {
+  @apply flex items-center gap-2;
+}
+
+.header-stat {
+  @apply flex items-center gap-2;
+}
+
+.header-stat-label {
+  @apply text-xs font-semibold text-wineneutral-400 uppercase tracking-wider;
+}
+
+.header-stat-value {
+  @apply font-bold text-brand-wine-600;
+}
+
+.header-title {
+  @apply flex flex-col gap-0.5;
+}
+
+.header-title-text {
+  @apply text-sm text-wineneutral-700 leading-snug line-clamp-2;
+}
+</style>

--- a/src/pages/annotate/_components/_index/AnonWarning.vue
+++ b/src/pages/annotate/_components/_index/AnonWarning.vue
@@ -1,58 +1,74 @@
 <template>
   <div
     v-if="!auth.isAuthenticated() && showAnonWarning"
-    class="relative rounded-lg border border-amber-300 bg-amber-50 p-4 text-amber-900"
+    class="notice notice--info"
   >
-    <!-- Close button -->
     <button
       @click="showAnonWarning = false"
-      class="absolute right-3 top-3 text-amber-700 hover:text-amber-900"
+      class="notice-close"
       aria-label="Dismiss warning"
     >
-      ✕
+      <svg
+        class="w-4 h-4"
+        fill="none"
+        viewBox="0 0 24 24"
+        stroke="currentColor"
+        stroke-width="2"
+      >
+        <path
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          d="M6 18L18 6M6 6l12 12"
+        />
+      </svg>
     </button>
 
-    <p class="font-semibold">You are accessing this as an anonymous user.</p>
+    <p class="notice-title">You are accessing this as an anonymous user.</p>
 
-    <p class="mt-1 text-sm">
+    <p class="notice-body">
       Anonymous users can make annotations, but their annotations weigh less
       than those made by signed-in users.
     </p>
 
-    <p class="mt-2 text-sm">
-      Click
-      <RouterLink
-        to="/sign-in"
-        class="font-medium underline hover:text-amber-800"
-      >
-        here
-      </RouterLink>
-      to sign in or
-      <RouterLink
-        to="/sign-up"
-        class="font-medium underline hover:text-amber-800"
-      >
-        here
-      </RouterLink>
-      to sign up.
+    <p class="notice-body">
+      <RouterLink to="/sign-in" class="notice-link">Sign in</RouterLink>
+      or
+      <RouterLink to="/sign-up" class="notice-link">sign up</RouterLink>
+      for your annotations to carry more weight.
     </p>
   </div>
 </template>
-<script lang="ts">
+
+<script setup lang="ts">
 import { useAuthStore } from '@/stores/auth';
 import { ref } from 'vue';
 
 const auth = useAuthStore();
-
-export default {
-  setup() {
-    const auth = useAuthStore();
-    const showAnonWarning = ref(true);
-
-    return {
-      auth,
-      showAnonWarning
-    };
-  }
-};
+const showAnonWarning = ref(true);
 </script>
+
+<style scoped>
+.notice {
+  @apply relative rounded-lg border p-4 pr-10 text-sm;
+}
+
+.notice--info {
+  @apply border-brand-wine-200 bg-brand-wine-50 text-brand-wine-900;
+}
+
+.notice-close {
+  @apply absolute right-3 top-3 text-brand-wine-400 hover:text-brand-wine-700 transition-colors;
+}
+
+.notice-title {
+  @apply font-semibold;
+}
+
+.notice-body {
+  @apply mt-1 text-brand-wine-700;
+}
+
+.notice-link {
+  @apply font-semibold underline underline-offset-2 hover:text-brand-wine-900 transition-colors;
+}
+</style>

--- a/src/pages/annotate/_components/_index/Modal.vue
+++ b/src/pages/annotate/_components/_index/Modal.vue
@@ -5,42 +5,44 @@
     <Transition name="fade">
       <div
         v-if="modelValue"
-        class="fixed inset-0 z-50"
+        class="modal-overlay"
         role="dialog"
         aria-modal="true"
         @keydown.esc="emitClose"
       >
         <!-- Dimmed backdrop -->
-        <div class="absolute inset-0 bg-black/100" @click="emitClose" />
+        <div class="modal-backdrop" @click="emitClose" />
 
         <!-- Modal panel -->
-        <div class="absolute inset-0 flex items-center justify-center p-4">
-          <div
-            class="w-full max-w-lg rounded-xl bg-brand-wine-900 shadow-xl"
-            @click.stop
-          >
-            <header class="flex items-center justify-between border-b p-4">
-              <h2 class="text-lg font-semibold">{{ title }}</h2>
-              <button
-                type="button"
-                class="rounded px-2 py-1 hover:bg-gray-100"
-                @click="emitClose"
-              >
-                ✕
+        <div class="modal-container">
+          <div class="modal-panel" @click.stop>
+            <header class="modal-header">
+              <h2 class="modal-title">{{ title }}</h2>
+              <button type="button" class="modal-close" @click="emitClose">
+                <svg
+                  class="w-5 h-5"
+                  fill="none"
+                  viewBox="0 0 24 24"
+                  stroke="currentColor"
+                  stroke-width="2"
+                >
+                  <path
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                    d="M6 18L18 6M6 6l12 12"
+                  />
+                </svg>
               </button>
             </header>
 
-            <div class="p-4">
+            <div class="modal-body">
               <slot />
             </div>
 
-            <footer class="flex justify-end gap-2 border-t p-4">
+            <footer class="modal-footer">
               <slot name="footer">
-                <button
-                  class="rounded border px-3 py-2 hover:bg-gray-50"
-                  @click="emitClose"
-                >
-                  Close
+                <button class="modal-btn" @click="emitClose">
+                  I understand
                 </button>
               </slot>
             </footer>
@@ -57,7 +59,7 @@ import { onMounted, onBeforeUnmount, watch } from 'vue';
 const props = defineProps<{
   modelValue: boolean;
   title?: string;
-  closeOnBackdrop?: boolean; // optional if you want to disable backdrop click
+  closeOnBackdrop?: boolean;
 }>();
 
 const emit = defineEmits<{
@@ -70,7 +72,7 @@ function emitClose() {
   emit('close');
 }
 
-// Optional: prevent background scroll when modal is open
+// Prevent background scroll when modal is open
 watch(
   () => props.modelValue,
   (open) => {
@@ -79,7 +81,7 @@ watch(
   { immediate: true }
 );
 
-// Optional: ensure ESC works even if focus isn't inside
+// ESC key support
 function onKeydown(e: KeyboardEvent) {
   if (e.key === 'Escape' && props.modelValue) emitClose();
 }
@@ -87,3 +89,56 @@ function onKeydown(e: KeyboardEvent) {
 onMounted(() => window.addEventListener('keydown', onKeydown));
 onBeforeUnmount(() => window.removeEventListener('keydown', onKeydown));
 </script>
+
+<style scoped>
+.modal-overlay {
+  @apply fixed inset-0 z-50;
+}
+
+.modal-backdrop {
+  @apply absolute inset-0 bg-black/80 backdrop-blur-sm;
+}
+
+.modal-container {
+  @apply absolute inset-0 flex items-center justify-center p-4;
+}
+
+.modal-panel {
+  @apply w-full max-w-lg rounded-xl bg-wineneutral-950 shadow-2xl border border-wineneutral-800 overflow-hidden;
+}
+
+.modal-header {
+  @apply flex items-center justify-between px-6 py-4 border-b border-wineneutral-800;
+}
+
+.modal-title {
+  @apply text-lg font-bold text-wineneutral-100;
+}
+
+.modal-close {
+  @apply text-wineneutral-500 hover:text-wineneutral-200 transition-colors p-1 rounded-md hover:bg-wineneutral-800;
+}
+
+.modal-body {
+  @apply px-6 py-5 text-sm text-wineneutral-300 leading-relaxed;
+}
+
+.modal-footer {
+  @apply flex justify-end px-6 py-4 border-t border-wineneutral-800;
+}
+
+.modal-btn {
+  @apply px-5 py-2.5 rounded-lg bg-brand-wine-600 text-white text-sm font-semibold transition-colors hover:bg-brand-wine-500;
+}
+
+/* Transitions */
+.fade-enter-active,
+.fade-leave-active {
+  transition: opacity 0.2s ease;
+}
+
+.fade-enter-from,
+.fade-leave-to {
+  opacity: 0;
+}
+</style>

--- a/src/pages/annotate/_components/_index/Reminder.vue
+++ b/src/pages/annotate/_components/_index/Reminder.vue
@@ -1,15 +1,27 @@
 <template>
-  <div
-    class="relative rounded-lg border border-amber-400 bg-amber-900 p-4 text-amber-50"
-  >
+  <div v-if="showReminder" class="notice notice--muted">
     <button
       @click="handleClose"
-      class="absolute right-3 top-3 text-amber-100 hover:text-amber-400"
-      aria-label="Dismiss warning"
+      class="notice-close"
+      aria-label="Dismiss reminder"
     >
-      ✕
+      <svg
+        class="w-4 h-4"
+        fill="none"
+        viewBox="0 0 24 24"
+        stroke="currentColor"
+        stroke-width="2"
+      >
+        <path
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          d="M6 18L18 6M6 6l12 12"
+        />
+      </svg>
     </button>
-    <slot />
+    <p class="text-sm">
+      <slot />
+    </p>
   </div>
 </template>
 
@@ -36,3 +48,17 @@ function handleClose(): void {
   showReminder.value = false;
 }
 </script>
+
+<style scoped>
+.notice {
+  @apply relative rounded-lg border p-4 pr-10;
+}
+
+.notice--muted {
+  @apply border-wineneutral-200 bg-wineneutral-50 text-wineneutral-700;
+}
+
+.notice-close {
+  @apply absolute right-3 top-3 text-wineneutral-400 hover:text-wineneutral-700 transition-colors;
+}
+</style>

--- a/src/pages/annotate/_components/_index/SupplementalInfo.vue
+++ b/src/pages/annotate/_components/_index/SupplementalInfo.vue
@@ -290,7 +290,7 @@
 }
 
 .suppl-link {
-  @apply text-amber-500 underline underline-offset-2 hover:text-amber-400 transition-colors;
+  @apply text-brand-gold-500 underline underline-offset-2 hover:text-brand-gold-400 transition-colors;
 }
 
 .suppl-list {

--- a/src/pages/annotate/_components/_index/SupplementalInfo.vue
+++ b/src/pages/annotate/_components/_index/SupplementalInfo.vue
@@ -1,209 +1,303 @@
 <template>
-  <div>
-    <div
-      class="grid grid-cols-2 gap-4 border-2 border-solid border-goldneutral-200"
-    >
-      <div class="col-span-1 text-sm">
-        <h3>Hints & Notes</h3>
-        <h3 class="text-med">What makes a relevant Data Source?</h3>
-        <p>
-          Data can be found in unexpected places. The page may not say "data"
-          anywhere on it. Check the list of Record Types below to see what we
-          consider relevant.
-        </p>
-        <h3 class="text-med">What agencies are relevant?</h3>
-        <p>
-          We include courts and jails because they often contain information
-          about police systems.
-        </p>
-        <h3 class="text-med">Individual Records</h3>
-        <p>
-          An incident report is an individual record; a list of incidents is a
-          data source.
-        </p>
-      </div>
-      <div class="col-span-1 text-sm">
-        <h3>Record Types Reference</h3>
-        <p>
-          <a
-            href="https://docs.pdap.io/activities/data-sources/data-dictionaries/record-types-taxonomy"
-          >
-            Read more about record types in the taxonomy
-          </a>
-        </p>
+  <details class="suppl-panel">
+    <summary class="suppl-toggle">
+      <svg
+        class="suppl-chevron"
+        fill="none"
+        viewBox="0 0 24 24"
+        stroke="currentColor"
+        stroke-width="2"
+      >
+        <path
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          d="M8.25 4.5l7.5 7.5-7.5 7.5"
+        />
+      </svg>
+      <span>Hints, Notes &amp; Record Types Reference</span>
+    </summary>
 
-        <h3 class="text-med">Police &amp; Public Interactions</h3>
-        <ul>
-          <li>
-            <strong>Accident Reports</strong>
-            : Vehicle accident records, often for people to look up their
-            reports.
-          </li>
-          <li>
-            <strong>Arrest Records</strong>
-            : Records of arrests within a jurisdiction.
-          </li>
-          <li>
-            <strong>Calls for Service</strong>
-            : Logs of officers responding to calls or initiating activity.
-          </li>
-          <li>
-            <strong>Car GPS</strong>
-            : Location data for police vehicles (rarely public).
-          </li>
-          <li>
-            <strong>Citations</strong>
-            : Low-level criminal offenses where citations were issued instead of
-            arrests.
-          </li>
-          <li>
-            <strong>Dispatch Logs</strong>
-            : Logs of calls/orders made by dispatchers.
-          </li>
-          <li>
-            <strong>Dispatch Recordings</strong>
-            : Audio feeds or archives of dispatch channels.
-          </li>
-          <li>
-            <strong>Field Contacts</strong>
-            : Reports of police-civilian interactions, including force or
-            routine contacts.
-          </li>
-          <li>
-            <strong>Incident Reports</strong>
-            : Reports written after responding to calls, criminal or not.
-          </li>
-          <li>
-            <strong>Misc Police Activity</strong>
-            : Police activities not covered by other categories.
-          </li>
-          <li>
-            <strong>Officer Involved Shootings</strong>
-            : Case files of shootings involving officers.
-          </li>
-          <li>
-            <strong>Stops</strong>
-            : Records of pedestrian or traffic stops.
-          </li>
-          <li>
-            <strong>Surveys</strong>
-            : Data collected from samples like inmates or judges.
-          </li>
-          <li>
-            <strong>Use of Force Reports</strong>
-            : Records of force used against civilians.
-          </li>
-          <li>
-            <strong>Vehicle Pursuits</strong>
-            : Records of police pursuits of fleeing vehicles.
-          </li>
-        </ul>
+    <div class="suppl-content">
+      <div class="suppl-grid">
+        <!-- Left column: Hints -->
+        <div class="suppl-section">
+          <h3 class="suppl-heading">Hints &amp; Notes</h3>
 
-        <hr />
+          <div class="suppl-card">
+            <h4 class="suppl-subheading">
+              What makes a relevant Data Source?
+            </h4>
+            <p>
+              Data can be found in unexpected places. The page may not say
+              "data" anywhere on it. Check the list of Record Types to see what
+              we consider relevant.
+            </p>
+          </div>
 
-        <h3 class="text-med">Info About Officers</h3>
-        <ul>
-          <li>
-            <strong>Complaints &amp; Misconduct</strong>
-            : Records/statistics on misconduct investigations.
-          </li>
-          <li>
-            <strong>Daily Activity Logs</strong>
-            : Shift reports or timesheets created by officers.
-          </li>
-          <li>
-            <strong>Training &amp; Hiring Info</strong>
-            : Information about officer training or hiring.
-          </li>
-          <li>
-            <strong>Personnel Records</strong>
-            : Records on hiring, firing, discipline, or certification.
-          </li>
-        </ul>
+          <div class="suppl-card">
+            <h4 class="suppl-subheading">What agencies are relevant?</h4>
+            <p>
+              We include courts and jails because they often contain information
+              about police systems.
+            </p>
+          </div>
 
-        <hr />
+          <div class="suppl-card">
+            <h4 class="suppl-subheading">Individual Records</h4>
+            <p>
+              An incident report is an individual record; a list of incidents is
+              a data source.
+            </p>
+          </div>
+        </div>
 
-        <h3 class="text-med">Info About Agencies</h3>
-        <ul>
-          <li>
-            <strong>Annual &amp; Monthly Reports</strong>
-            : Summary documents about police activities.
-          </li>
-          <li>
-            <strong>Budgets &amp; Finances</strong>
-            : Budgets, grants, and financial records.
-          </li>
-          <li>
-            <strong>Geographic</strong>
-            : Maps or data on jurisdiction zones/sectors.
-          </li>
-          <li>
-            <strong>List of Data Sources</strong>
-            : Collections of links to datasets or portals.
-          </li>
-          <li>
-            <strong>Policies &amp; Contracts</strong>
-            : Policies or procedural contracts.
-          </li>
-        </ul>
+        <!-- Right column: Record Types -->
+        <div class="suppl-section">
+          <h3 class="suppl-heading">Record Types Reference</h3>
+          <p class="suppl-link-text">
+            <a
+              href="https://docs.pdap.io/activities/data-sources/data-dictionaries/record-types-taxonomy"
+              class="suppl-link"
+            >
+              Read more about record types in the taxonomy
+            </a>
+          </p>
 
-        <hr />
+          <div class="suppl-card">
+            <h4 class="suppl-subheading">
+              Police &amp; Public Interactions
+            </h4>
+            <ul class="suppl-list">
+              <li>
+                <strong>Accident Reports</strong> &mdash; Vehicle accident
+                records
+              </li>
+              <li>
+                <strong>Arrest Records</strong> &mdash; Records of arrests
+                within a jurisdiction
+              </li>
+              <li>
+                <strong>Calls for Service</strong> &mdash; Logs of officers
+                responding to calls
+              </li>
+              <li>
+                <strong>Car GPS</strong> &mdash; Location data for police
+                vehicles
+              </li>
+              <li>
+                <strong>Citations</strong> &mdash; Low-level criminal offenses
+              </li>
+              <li>
+                <strong>Dispatch Logs</strong> &mdash; Logs of calls/orders by
+                dispatchers
+              </li>
+              <li>
+                <strong>Dispatch Recordings</strong> &mdash; Audio feeds of
+                dispatch channels
+              </li>
+              <li>
+                <strong>Field Contacts</strong> &mdash; Reports of
+                police-civilian interactions
+              </li>
+              <li>
+                <strong>Incident Reports</strong> &mdash; Reports after
+                responding to calls
+              </li>
+              <li>
+                <strong>Misc Police Activity</strong> &mdash; Uncategorized
+                police activities
+              </li>
+              <li>
+                <strong>Officer Involved Shootings</strong> &mdash; Case files
+                of OIS
+              </li>
+              <li>
+                <strong>Stops</strong> &mdash; Records of pedestrian or traffic
+                stops
+              </li>
+              <li>
+                <strong>Surveys</strong> &mdash; Data from samples like inmates
+                or judges
+              </li>
+              <li>
+                <strong>Use of Force Reports</strong> &mdash; Records of force
+                used
+              </li>
+              <li>
+                <strong>Vehicle Pursuits</strong> &mdash; Records of police
+                pursuits
+              </li>
+            </ul>
+          </div>
 
-        <h3 class="text-med">Agency-Published Resources</h3>
-        <ul>
-          <li>
-            <strong>Crime Maps &amp; Reports</strong>
-            : Individual crimes shown in maps/tables.
-          </li>
-          <li>
-            <strong>Crime Statistics</strong>
-            : Summarized crime statistics for jurisdictions.
-          </li>
-          <li>
-            <strong>Media Bulletins</strong>
-            : Blotters, press releases, or alerts.
-          </li>
-          <li>
-            <strong>Records Request Info</strong>
-            : Forms, portals, or policies for records requests.
-          </li>
-          <li>
-            <strong>Resources</strong>
-            : Guidance on services, fees, or practices.
-          </li>
-          <li>
-            <strong>Sex Offender Registry</strong>
-            : Indexes of registered sex offenders.
-          </li>
-          <li>
-            <strong>Wanted Persons</strong>
-            : Lists of people with outstanding warrants.
-          </li>
-        </ul>
+          <div class="suppl-card">
+            <h4 class="suppl-subheading">Info About Officers</h4>
+            <ul class="suppl-list">
+              <li>
+                <strong>Complaints &amp; Misconduct</strong> &mdash; Misconduct
+                investigations
+              </li>
+              <li>
+                <strong>Daily Activity Logs</strong> &mdash; Shift reports or
+                timesheets
+              </li>
+              <li>
+                <strong>Training &amp; Hiring Info</strong> &mdash; Officer
+                training/hiring
+              </li>
+              <li>
+                <strong>Personnel Records</strong> &mdash; Hiring, firing,
+                discipline, certification
+              </li>
+            </ul>
+          </div>
 
-        <hr />
+          <div class="suppl-card">
+            <h4 class="suppl-subheading">Info About Agencies</h4>
+            <ul class="suppl-list">
+              <li>
+                <strong>Annual &amp; Monthly Reports</strong> &mdash; Summary
+                documents
+              </li>
+              <li>
+                <strong>Budgets &amp; Finances</strong> &mdash; Budgets,
+                grants, financial records
+              </li>
+              <li>
+                <strong>Geographic</strong> &mdash; Maps or data on
+                jurisdiction zones
+              </li>
+              <li>
+                <strong>List of Data Sources</strong> &mdash; Collections of
+                dataset links
+              </li>
+              <li>
+                <strong>Policies &amp; Contracts</strong> &mdash; Policies or
+                procedural contracts
+              </li>
+            </ul>
+          </div>
 
-        <h3 class="text-med">Jails &amp; Courts Specific</h3>
-        <ul>
-          <li>
-            <strong>Booking Reports</strong>
-            : Records of booking/intake into jails.
-          </li>
-          <li>
-            <strong>Court Cases</strong>
-            : Dockets or other case-related records.
-          </li>
-          <li>
-            <strong>Incarceration Records</strong>
-            : Current inmate rosters, often with release notifications.
-          </li>
-        </ul>
+          <div class="suppl-card">
+            <h4 class="suppl-subheading">Agency-Published Resources</h4>
+            <ul class="suppl-list">
+              <li>
+                <strong>Crime Maps &amp; Reports</strong> &mdash; Individual
+                crimes in maps/tables
+              </li>
+              <li>
+                <strong>Crime Statistics</strong> &mdash; Summarized crime
+                stats
+              </li>
+              <li>
+                <strong>Media Bulletins</strong> &mdash; Blotters, press
+                releases, alerts
+              </li>
+              <li>
+                <strong>Records Request Info</strong> &mdash; Forms, portals, or
+                policies
+              </li>
+              <li>
+                <strong>Resources</strong> &mdash; Guidance on services, fees,
+                or practices
+              </li>
+              <li>
+                <strong>Sex Offender Registry</strong> &mdash; Indexes of
+                registered offenders
+              </li>
+              <li>
+                <strong>Wanted Persons</strong> &mdash; Lists of people with
+                warrants
+              </li>
+            </ul>
+          </div>
+
+          <div class="suppl-card">
+            <h4 class="suppl-subheading">Jails &amp; Courts Specific</h4>
+            <ul class="suppl-list">
+              <li>
+                <strong>Booking Reports</strong> &mdash; Records of jail
+                booking/intake
+              </li>
+              <li>
+                <strong>Court Cases</strong> &mdash; Dockets or case-related
+                records
+              </li>
+              <li>
+                <strong>Incarceration Records</strong> &mdash; Current inmate
+                rosters
+              </li>
+            </ul>
+          </div>
+        </div>
       </div>
     </div>
-  </div>
+  </details>
 </template>
-<script>
-export default {
-  name: 'SupplementalInfo'
-};
+
+<script setup lang="ts">
+// No logic needed — pure presentational component
 </script>
+
+<style scoped>
+.suppl-panel {
+  @apply mt-8 rounded-xl border-2 border-wineneutral-200 overflow-hidden;
+}
+
+.suppl-toggle {
+  @apply flex items-center gap-2 px-5 py-4 cursor-pointer text-sm font-bold text-wineneutral-600 uppercase tracking-wider select-none hover:bg-wineneutral-50 transition-colors;
+  list-style: none;
+}
+
+.suppl-toggle::-webkit-details-marker {
+  display: none;
+}
+
+.suppl-chevron {
+  @apply w-4 h-4 transition-transform duration-200 shrink-0;
+}
+
+.suppl-panel[open] .suppl-chevron {
+  transform: rotate(90deg);
+}
+
+.suppl-content {
+  @apply px-5 pb-5;
+}
+
+.suppl-grid {
+  @apply grid grid-cols-1 md:grid-cols-2 gap-6;
+}
+
+.suppl-section {
+  @apply space-y-3;
+}
+
+.suppl-heading {
+  @apply text-sm font-bold text-brand-wine-600 uppercase tracking-wider pb-2 border-b border-wineneutral-200;
+}
+
+.suppl-card {
+  @apply bg-wineneutral-50 rounded-lg p-3 text-sm text-wineneutral-700 leading-relaxed;
+}
+
+.suppl-subheading {
+  @apply text-xs font-bold text-wineneutral-800 uppercase tracking-wider mb-1;
+}
+
+.suppl-link-text {
+  @apply text-sm;
+}
+
+.suppl-link {
+  @apply text-brand-wine-600 underline underline-offset-2 hover:text-brand-wine-800 transition-colors;
+}
+
+.suppl-list {
+  @apply space-y-1 mt-1;
+}
+
+.suppl-list li {
+  @apply text-xs leading-relaxed;
+}
+</style>

--- a/src/pages/annotate/_components/_index/SupplementalInfo.vue
+++ b/src/pages/annotate/_components/_index/SupplementalInfo.vue
@@ -290,7 +290,7 @@
 }
 
 .suppl-link {
-  @apply text-brand-gold-500 underline underline-offset-2 hover:text-brand-gold-400 transition-colors;
+  @apply text-goldneutral-700 underline underline-offset-2 hover:text-goldneutral-800 transition-colors;
 }
 
 .suppl-list {

--- a/src/pages/annotate/_components/_index/SupplementalInfo.vue
+++ b/src/pages/annotate/_components/_index/SupplementalInfo.vue
@@ -290,7 +290,7 @@
 }
 
 .suppl-link {
-  @apply text-brand-wine-600 underline underline-offset-2 hover:text-brand-wine-800 transition-colors;
+  @apply text-amber-500 underline underline-offset-2 hover:text-amber-400 transition-colors;
 }
 
 .suppl-list {

--- a/src/pages/annotate/_components/_index/TabControls.vue
+++ b/src/pages/annotate/_components/_index/TabControls.vue
@@ -1,20 +1,45 @@
-<!-- src/components/StepControls.vue -->
 <template>
-  <div class="mt-6 flex justify-between items-center">
+  <div class="tab-controls">
     <button
-      class="px-4 py-2 pdap-button-secondary text-sm"
+      class="tab-controls-btn tab-controls-btn--secondary"
       :disabled="currentIndex === 0"
       @click="emit('prev')"
     >
+      <svg
+        class="w-4 h-4"
+        fill="none"
+        viewBox="0 0 24 24"
+        stroke="currentColor"
+        stroke-width="2"
+      >
+        <path
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          d="M15.75 19.5L8.25 12l7.5-7.5"
+        />
+      </svg>
       Previous
     </button>
 
     <button
-      class="px-4 py-2 pdap-button-primary text-sm"
+      class="tab-controls-btn tab-controls-btn--primary"
       :disabled="isNextDisabled"
       @click="emit('next')"
     >
       {{ nextTextModel }}
+      <svg
+        class="w-4 h-4"
+        fill="none"
+        viewBox="0 0 24 24"
+        stroke="currentColor"
+        stroke-width="2"
+      >
+        <path
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          d="M8.25 4.5l7.5 7.5-7.5 7.5"
+        />
+      </svg>
     </button>
   </div>
 </template>
@@ -39,3 +64,33 @@ const emit = defineEmits<{
   (e: 'next'): void;
 }>();
 </script>
+
+<style scoped>
+.tab-controls {
+  @apply mt-4 flex justify-between items-center gap-3;
+}
+
+.tab-controls-btn {
+  @apply inline-flex items-center gap-2 px-5 py-2.5 rounded-lg text-sm font-semibold transition-all duration-150;
+}
+
+.tab-controls-btn:disabled {
+  @apply opacity-40 cursor-not-allowed;
+}
+
+.tab-controls-btn--secondary {
+  @apply bg-wineneutral-100 text-wineneutral-700 border border-wineneutral-300;
+}
+
+.tab-controls-btn--secondary:not(:disabled):hover {
+  @apply bg-wineneutral-200 border-wineneutral-400;
+}
+
+.tab-controls-btn--primary {
+  @apply bg-brand-wine-600 text-white border border-brand-wine-700;
+}
+
+.tab-controls-btn--primary:not(:disabled):hover {
+  @apply bg-brand-wine-700;
+}
+</style>

--- a/src/pages/annotate/_components/_index/TabControls.vue
+++ b/src/pages/annotate/_components/_index/TabControls.vue
@@ -87,10 +87,10 @@ const emit = defineEmits<{
 }
 
 .tab-controls-btn--primary {
-  @apply bg-amber-600 text-white border border-amber-700;
+  @apply bg-brand-gold-600 text-white border border-brand-gold-700;
 }
 
 .tab-controls-btn--primary:not(:disabled):hover {
-  @apply bg-amber-500;
+  @apply bg-brand-gold-500;
 }
 </style>

--- a/src/pages/annotate/_components/_index/TabControls.vue
+++ b/src/pages/annotate/_components/_index/TabControls.vue
@@ -79,18 +79,18 @@ const emit = defineEmits<{
 }
 
 .tab-controls-btn--secondary {
-  @apply bg-wineneutral-100 text-wineneutral-700 border border-wineneutral-300;
+  @apply bg-wineneutral-800 text-wineneutral-100 border border-wineneutral-600;
 }
 
 .tab-controls-btn--secondary:not(:disabled):hover {
-  @apply bg-wineneutral-200 border-wineneutral-400;
+  @apply bg-wineneutral-700 border-wineneutral-500;
 }
 
 .tab-controls-btn--primary {
-  @apply bg-brand-wine-600 text-white border border-brand-wine-700;
+  @apply bg-amber-600 text-white border border-amber-700;
 }
 
 .tab-controls-btn--primary:not(:disabled):hover {
-  @apply bg-brand-wine-700;
+  @apply bg-amber-500;
 }
 </style>

--- a/src/pages/annotate/_components/_index/TabsHeader.vue
+++ b/src/pages/annotate/_components/_index/TabsHeader.vue
@@ -1,18 +1,89 @@
 <template>
-  <div class="border-b border-gray-300 flex items-center gap-2">
-    <div
-      v-for="(tab, index) in tabs"
-      :key="tab.id"
-      class="py-2 px-4 -mb-px border-b-2 cursor-pointer"
-      :class="[getClasses(index), mobileVisibility(index)]"
-      @click="emit('select', index)"
-    >
-      {{ tab.name }}
+  <!-- Desktop stepper -->
+  <nav class="stepper-desktop" aria-label="Annotation steps">
+    <template v-for="(tab, index) in tabs" :key="tab.id">
+      <button
+        class="stepper-step"
+        :class="{ 'stepper-step--clickable': isClickable(index) }"
+        :disabled="!isClickable(index)"
+        @click="isClickable(index) && emit('select', index)"
+      >
+        <!-- Circle -->
+        <div class="stepper-circle" :class="getCircleClasses(index)">
+          <!-- Checkmark for answered -->
+          <svg
+            v-if="answeredIndices.includes(index) && index !== currentIndex"
+            class="w-3.5 h-3.5"
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke="currentColor"
+            stroke-width="3"
+          >
+            <path
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              d="M4.5 12.75l6 6 9-13.5"
+            />
+          </svg>
+          <!-- Dash for skipped -->
+          <svg
+            v-else-if="skippedIndices.includes(index)"
+            class="w-3 h-3"
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke="currentColor"
+            stroke-width="3"
+          >
+            <path
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              d="M5 12h14"
+            />
+          </svg>
+          <!-- Number otherwise -->
+          <span v-else class="text-xs font-bold">{{ index + 1 }}</span>
+        </div>
+
+        <!-- Label -->
+        <span class="stepper-label" :class="getLabelClasses(index)">
+          {{ tab.name }}
+        </span>
+      </button>
+
+      <!-- Connecting line -->
+      <div
+        v-if="index < tabs.length - 1"
+        class="stepper-line"
+        :class="getLineClasses(index)"
+      />
+    </template>
+  </nav>
+
+  <!-- Mobile stepper -->
+  <nav class="stepper-mobile" aria-label="Annotation steps">
+    <div class="stepper-mobile-info">
+      <span class="stepper-mobile-label">{{ tabs[currentIndex]?.name }}</span>
+      <span class="stepper-mobile-count">
+        Step {{ currentStepNumber }} of {{ totalSteps }}
+      </span>
     </div>
-  </div>
+    <div class="stepper-dots">
+      <button
+        v-for="(tab, i) in tabs"
+        :key="i"
+        class="stepper-dot"
+        :class="getDotClasses(i)"
+        :disabled="!isClickable(i)"
+        :aria-label="`Step ${i + 1}: ${tab.name}`"
+        @click="isClickable(i) && emit('select', i)"
+      />
+    </div>
+  </nav>
 </template>
 
 <script setup lang="ts">
+import { computed } from 'vue';
+
 //====================
 //       Types
 //====================
@@ -37,33 +108,224 @@ const emit = defineEmits<{
 }>();
 
 //====================
+// Computed Variables
+//====================
+const currentStepNumber = computed(() => {
+  const enabledBefore = props.enabledIndices.filter(
+    (i) => i <= props.currentIndex
+  );
+  return enabledBefore.length || 1;
+});
+
+const totalSteps = computed(
+  () => props.enabledIndices.length || props.tabs.length
+);
+
+//====================
 //      Helpers
 //====================
-function mobileVisibility(index: number) {
-  // Hidden on small screens unless it's the current tab; always show from md+
-  return index === props.currentIndex
-    ? 'block text-center md:text-left mx-auto md:mx-0'
-    : 'hidden md:block';
+function isClickable(index: number): boolean {
+  return props.enabledIndices.includes(index);
 }
 
-function getClasses(index: number) {
-  // Selected/Current Tab
+function getCircleClasses(index: number): string {
   if (index === props.currentIndex) {
-    return 'text-brand-wine-500 font-bold hover:bg-amber-800';
+    return 'stepper-circle--active';
   }
-  // Completed Tab
   if (props.answeredIndices.includes(index)) {
-    return 'text-wineneutral-500 font-bold hover:bg-amber-800';
+    return 'stepper-circle--completed';
   }
-  // Skipped Tab
   if (props.skippedIndices.includes(index)) {
-    return 'text-wineneutral-300 line-through hover:bg-amber-800';
+    return 'stepper-circle--skipped';
   }
-  // Enabled Tab Not Yet Accessed/Future Inactive
   if (props.enabledIndices.includes(index)) {
-    return 'text-wineneutral-700 hover:bg-amber-800';
+    return 'stepper-circle--enabled';
   }
-  // Disabled Tab
-  return 'text-wineneutral-300';
+  return 'stepper-circle--disabled';
+}
+
+function getLabelClasses(index: number): string {
+  if (index === props.currentIndex) {
+    return 'stepper-label--active';
+  }
+  if (props.answeredIndices.includes(index)) {
+    return 'stepper-label--completed';
+  }
+  if (props.skippedIndices.includes(index)) {
+    return 'stepper-label--skipped';
+  }
+  if (props.enabledIndices.includes(index)) {
+    return 'stepper-label--enabled';
+  }
+  return 'stepper-label--disabled';
+}
+
+function getLineClasses(index: number): string {
+  const nextIndex = index + 1;
+  if (
+    props.answeredIndices.includes(index) &&
+    (props.answeredIndices.includes(nextIndex) ||
+      nextIndex === props.currentIndex)
+  ) {
+    return 'stepper-line--completed';
+  }
+  if (
+    props.enabledIndices.includes(index) &&
+    props.enabledIndices.includes(nextIndex)
+  ) {
+    return 'stepper-line--enabled';
+  }
+  return 'stepper-line--disabled';
+}
+
+function getDotClasses(index: number): string {
+  if (index === props.currentIndex) {
+    return 'stepper-dot--active';
+  }
+  if (props.answeredIndices.includes(index)) {
+    return 'stepper-dot--completed';
+  }
+  if (props.skippedIndices.includes(index)) {
+    return 'stepper-dot--skipped';
+  }
+  if (props.enabledIndices.includes(index)) {
+    return 'stepper-dot--enabled';
+  }
+  return 'stepper-dot--disabled';
 }
 </script>
+
+<style scoped>
+/* Desktop stepper */
+.stepper-desktop {
+  @apply hidden md:flex items-center;
+}
+
+.stepper-step {
+  @apply flex flex-col items-center gap-1.5 bg-transparent border-none p-0 min-w-0;
+}
+
+.stepper-step--clickable {
+  @apply cursor-pointer;
+}
+
+.stepper-step--clickable:hover .stepper-circle--enabled,
+.stepper-step--clickable:hover .stepper-circle--completed {
+  @apply ring-2 ring-brand-wine-200 ring-offset-1;
+}
+
+/* Circles */
+.stepper-circle {
+  @apply w-8 h-8 rounded-full flex items-center justify-center transition-all duration-200 shrink-0;
+}
+
+.stepper-circle--active {
+  @apply bg-brand-wine-600 text-white;
+  box-shadow:
+    0 0 0 3px color-mix(in srgb, var(--color-brand-wine-600) 20%, transparent),
+    0 2px 4px rgba(0, 0, 0, 0.1);
+}
+
+.stepper-circle--completed {
+  @apply bg-brand-gold-500 text-white;
+}
+
+.stepper-circle--skipped {
+  @apply bg-wineneutral-200 text-wineneutral-500;
+}
+
+.stepper-circle--enabled {
+  @apply bg-wineneutral-100 text-wineneutral-600 border-2 border-wineneutral-300;
+}
+
+.stepper-circle--disabled {
+  @apply bg-wineneutral-50 text-wineneutral-300 border border-wineneutral-200;
+}
+
+/* Labels */
+.stepper-label {
+  @apply text-xs font-medium whitespace-nowrap transition-colors hidden lg:block;
+}
+
+.stepper-label--active {
+  @apply text-brand-wine-700 font-bold;
+}
+
+.stepper-label--completed {
+  @apply text-brand-gold-700;
+}
+
+.stepper-label--skipped {
+  @apply text-wineneutral-400 line-through;
+}
+
+.stepper-label--enabled {
+  @apply text-wineneutral-600;
+}
+
+.stepper-label--disabled {
+  @apply text-wineneutral-300;
+}
+
+/* Connecting lines */
+.stepper-line {
+  @apply flex-1 h-0.5 mx-1.5 rounded-full transition-colors duration-200 self-start mt-4;
+}
+
+.stepper-line--completed {
+  @apply bg-brand-gold-400;
+}
+
+.stepper-line--enabled {
+  @apply bg-wineneutral-200;
+}
+
+.stepper-line--disabled {
+  @apply bg-wineneutral-100;
+}
+
+/* Mobile stepper */
+.stepper-mobile {
+  @apply flex md:hidden flex-col gap-3 px-1;
+}
+
+.stepper-mobile-info {
+  @apply flex items-center justify-between;
+}
+
+.stepper-mobile-label {
+  @apply text-lg font-bold text-brand-wine-700;
+}
+
+.stepper-mobile-count {
+  @apply text-sm text-wineneutral-500;
+}
+
+.stepper-dots {
+  @apply flex items-center gap-2 justify-center;
+}
+
+.stepper-dot {
+  @apply w-2.5 h-2.5 rounded-full transition-all duration-200 p-0 border-none;
+}
+
+.stepper-dot--active {
+  @apply bg-brand-wine-600 scale-125;
+}
+
+.stepper-dot--completed {
+  @apply bg-brand-gold-500 cursor-pointer;
+}
+
+.stepper-dot--skipped {
+  @apply bg-wineneutral-300;
+}
+
+.stepper-dot--enabled {
+  @apply bg-wineneutral-200 cursor-pointer;
+}
+
+.stepper-dot--disabled {
+  @apply bg-wineneutral-100;
+}
+</style>

--- a/src/pages/annotate/_components/_index/TabsHeader.vue
+++ b/src/pages/annotate/_components/_index/TabsHeader.vue
@@ -211,7 +211,7 @@ function getDotClasses(index: number): string {
 
 .stepper-step--clickable:hover .stepper-circle--enabled,
 .stepper-step--clickable:hover .stepper-circle--completed {
-  @apply ring-2 ring-brand-gold-400/30 ring-offset-1;
+  @apply ring-2 ring-wineneutral-400/30 ring-offset-1;
 }
 
 /* Circles */
@@ -220,14 +220,14 @@ function getDotClasses(index: number): string {
 }
 
 .stepper-circle--active {
-  @apply bg-brand-gold-600 text-white;
+  @apply bg-brand-wine-500 text-white;
   box-shadow:
-    0 0 0 3px rgba(213, 162, 60, 0.2),
+    0 0 0 3px rgba(81, 42, 79, 0.2),
     0 2px 4px rgba(0, 0, 0, 0.1);
 }
 
 .stepper-circle--completed {
-  @apply bg-brand-gold-500 text-white;
+  @apply bg-wineneutral-500 text-white;
 }
 
 .stepper-circle--skipped {
@@ -248,11 +248,11 @@ function getDotClasses(index: number): string {
 }
 
 .stepper-label--active {
-  @apply text-brand-gold-400 font-bold;
+  @apply text-wineneutral-200 font-bold;
 }
 
 .stepper-label--completed {
-  @apply text-brand-gold-500;
+  @apply text-wineneutral-400;
 }
 
 .stepper-label--skipped {
@@ -273,7 +273,7 @@ function getDotClasses(index: number): string {
 }
 
 .stepper-line--completed {
-  @apply bg-brand-gold-400;
+  @apply bg-wineneutral-400;
 }
 
 .stepper-line--enabled {
@@ -294,7 +294,7 @@ function getDotClasses(index: number): string {
 }
 
 .stepper-mobile-label {
-  @apply text-lg font-bold text-brand-gold-400;
+  @apply text-lg font-bold text-wineneutral-200;
 }
 
 .stepper-mobile-count {
@@ -310,11 +310,11 @@ function getDotClasses(index: number): string {
 }
 
 .stepper-dot--active {
-  @apply bg-brand-gold-500 scale-125;
+  @apply bg-brand-wine-400 scale-125;
 }
 
 .stepper-dot--completed {
-  @apply bg-brand-gold-500 cursor-pointer;
+  @apply bg-wineneutral-400 cursor-pointer;
 }
 
 .stepper-dot--skipped {

--- a/src/pages/annotate/_components/_index/TabsHeader.vue
+++ b/src/pages/annotate/_components/_index/TabsHeader.vue
@@ -211,7 +211,7 @@ function getDotClasses(index: number): string {
 
 .stepper-step--clickable:hover .stepper-circle--enabled,
 .stepper-step--clickable:hover .stepper-circle--completed {
-  @apply ring-2 ring-brand-wine-200 ring-offset-1;
+  @apply ring-2 ring-amber-400/30 ring-offset-1;
 }
 
 /* Circles */
@@ -220,9 +220,9 @@ function getDotClasses(index: number): string {
 }
 
 .stepper-circle--active {
-  @apply bg-brand-wine-600 text-white;
+  @apply bg-amber-600 text-white;
   box-shadow:
-    0 0 0 3px color-mix(in srgb, var(--color-brand-wine-600) 20%, transparent),
+    0 0 0 3px rgba(245, 158, 11, 0.2),
     0 2px 4px rgba(0, 0, 0, 0.1);
 }
 
@@ -248,19 +248,19 @@ function getDotClasses(index: number): string {
 }
 
 .stepper-label--active {
-  @apply text-brand-wine-700 font-bold;
+  @apply text-amber-400 font-bold;
 }
 
 .stepper-label--completed {
-  @apply text-brand-gold-700;
+  @apply text-brand-gold-500;
 }
 
 .stepper-label--skipped {
-  @apply text-wineneutral-400 line-through;
+  @apply text-wineneutral-500 line-through;
 }
 
 .stepper-label--enabled {
-  @apply text-wineneutral-600;
+  @apply text-wineneutral-300;
 }
 
 .stepper-label--disabled {
@@ -294,11 +294,11 @@ function getDotClasses(index: number): string {
 }
 
 .stepper-mobile-label {
-  @apply text-lg font-bold text-brand-wine-700;
+  @apply text-lg font-bold text-amber-400;
 }
 
 .stepper-mobile-count {
-  @apply text-sm text-wineneutral-500;
+  @apply text-sm text-wineneutral-300;
 }
 
 .stepper-dots {
@@ -310,7 +310,7 @@ function getDotClasses(index: number): string {
 }
 
 .stepper-dot--active {
-  @apply bg-brand-wine-600 scale-125;
+  @apply bg-amber-500 scale-125;
 }
 
 .stepper-dot--completed {

--- a/src/pages/annotate/_components/_index/TabsHeader.vue
+++ b/src/pages/annotate/_components/_index/TabsHeader.vue
@@ -211,7 +211,7 @@ function getDotClasses(index: number): string {
 
 .stepper-step--clickable:hover .stepper-circle--enabled,
 .stepper-step--clickable:hover .stepper-circle--completed {
-  @apply ring-2 ring-amber-400/30 ring-offset-1;
+  @apply ring-2 ring-brand-gold-400/30 ring-offset-1;
 }
 
 /* Circles */
@@ -220,9 +220,9 @@ function getDotClasses(index: number): string {
 }
 
 .stepper-circle--active {
-  @apply bg-amber-600 text-white;
+  @apply bg-brand-gold-600 text-white;
   box-shadow:
-    0 0 0 3px rgba(245, 158, 11, 0.2),
+    0 0 0 3px rgba(213, 162, 60, 0.2),
     0 2px 4px rgba(0, 0, 0, 0.1);
 }
 
@@ -248,7 +248,7 @@ function getDotClasses(index: number): string {
 }
 
 .stepper-label--active {
-  @apply text-amber-400 font-bold;
+  @apply text-brand-gold-400 font-bold;
 }
 
 .stepper-label--completed {
@@ -294,7 +294,7 @@ function getDotClasses(index: number): string {
 }
 
 .stepper-mobile-label {
-  @apply text-lg font-bold text-amber-400;
+  @apply text-lg font-bold text-brand-gold-400;
 }
 
 .stepper-mobile-count {
@@ -310,7 +310,7 @@ function getDotClasses(index: number): string {
 }
 
 .stepper-dot--active {
-  @apply bg-amber-500 scale-125;
+  @apply bg-brand-gold-500 scale-125;
 }
 
 .stepper-dot--completed {

--- a/src/pages/annotate/_components/_index/ZoomableImage.vue
+++ b/src/pages/annotate/_components/_index/ZoomableImage.vue
@@ -137,7 +137,7 @@ const lensStyle = computed(() => {
 }
 
 .zoom-lens {
-  @apply absolute rounded-full pointer-events-none border-2 border-amber-400/70;
+  @apply absolute rounded-full pointer-events-none border-2 border-goldneutral-400/70;
   box-shadow:
     0 0 0 1px rgba(0, 0, 0, 0.3),
     0 4px 12px rgba(0, 0, 0, 0.4);

--- a/src/pages/annotate/_components/_index/ZoomableImage.vue
+++ b/src/pages/annotate/_components/_index/ZoomableImage.vue
@@ -1,0 +1,139 @@
+<template>
+  <div
+    ref="containerRef"
+    class="zoom-container"
+    @mouseenter="hovering = true"
+    @mouseleave="hovering = false"
+    @mousemove="onMouseMove"
+    @click="openFullSize"
+  >
+    <img
+      :src="src"
+      :alt="alt"
+      class="zoom-image"
+      @error="$emit('error')"
+    />
+
+    <!-- Magnifier lens -->
+    <div
+      v-if="hovering && loaded"
+      class="zoom-lens"
+      :style="lensStyle"
+    />
+
+    <!-- Hint overlay -->
+    <div v-if="!hovering" class="zoom-hint">
+      <svg
+        class="w-5 h-5"
+        fill="none"
+        viewBox="0 0 24 24"
+        stroke="currentColor"
+        stroke-width="1.5"
+      >
+        <path
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          d="m21 21-5.197-5.197m0 0A7.5 7.5 0 1 0 5.196 5.196a7.5 7.5 0 0 0 10.607 10.607ZM10.5 7.5v6m3-3h-6"
+        />
+      </svg>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref, computed, onMounted } from 'vue';
+
+const props = defineProps<{
+  src: string;
+  alt?: string;
+  zoomScale?: number;
+}>();
+
+defineEmits<{
+  (e: 'error'): void;
+}>();
+
+const ZOOM = props.zoomScale ?? 2.5;
+const LENS_SIZE = 160;
+
+const containerRef = ref<HTMLElement | null>(null);
+const hovering = ref(false);
+const loaded = ref(false);
+const mouseX = ref(0);
+const mouseY = ref(0);
+
+onMounted(() => {
+  const img = containerRef.value?.querySelector('img');
+  if (img) {
+    if (img.complete) {
+      loaded.value = true;
+    } else {
+      img.addEventListener('load', () => {
+        loaded.value = true;
+      });
+    }
+  }
+});
+
+function onMouseMove(e: MouseEvent) {
+  if (!containerRef.value) return;
+  const rect = containerRef.value.getBoundingClientRect();
+  mouseX.value = e.clientX - rect.left;
+  mouseY.value = e.clientY - rect.top;
+}
+
+function openFullSize() {
+  window.open(props.src, '_blank');
+}
+
+const lensStyle = computed(() => {
+  if (!containerRef.value) return {};
+
+  const el = containerRef.value;
+  const img = el.querySelector('img');
+  if (!img) return {};
+
+  const containerW = el.offsetWidth;
+  const containerH = el.offsetHeight;
+
+  // Clamp lens position so it doesn't go outside the image
+  const lensX = Math.max(0, Math.min(mouseX.value - LENS_SIZE / 2, containerW - LENS_SIZE));
+  const lensY = Math.max(0, Math.min(mouseY.value - LENS_SIZE / 2, containerH - LENS_SIZE));
+
+  // Background position: where in the zoomed image to show
+  const bgX = (mouseX.value / containerW) * 100;
+  const bgY = (mouseY.value / containerH) * 100;
+
+  return {
+    width: `${LENS_SIZE}px`,
+    height: `${LENS_SIZE}px`,
+    left: `${lensX}px`,
+    top: `${lensY}px`,
+    backgroundImage: `url(${props.src})`,
+    backgroundSize: `${containerW * ZOOM}px ${containerH * ZOOM}px`,
+    backgroundPosition: `${bgX}% ${bgY}%`,
+  };
+});
+</script>
+
+<style scoped>
+.zoom-container {
+  @apply relative overflow-hidden cursor-zoom-in select-none;
+}
+
+.zoom-image {
+  @apply w-full h-full object-cover object-top;
+}
+
+.zoom-lens {
+  @apply absolute rounded-full pointer-events-none border-2 border-amber-400/70;
+  box-shadow:
+    0 0 0 1px rgba(0, 0, 0, 0.3),
+    0 4px 12px rgba(0, 0, 0, 0.4);
+  z-index: 10;
+}
+
+.zoom-hint {
+  @apply absolute bottom-2 right-2 bg-black/50 text-white/80 rounded-lg px-2 py-1.5 flex items-center gap-1.5 text-xs pointer-events-none backdrop-blur-sm;
+}
+</style>

--- a/src/pages/annotate/_components/_index/ZoomableImage.vue
+++ b/src/pages/annotate/_components/_index/ZoomableImage.vue
@@ -2,9 +2,10 @@
   <div
     ref="containerRef"
     class="zoom-container"
-    @mouseenter="hovering = true"
+    :class="{ 'zoom-container--pointer': hasPointer }"
+    @mouseenter="hasPointer && (hovering = true)"
     @mouseleave="hovering = false"
-    @mousemove="onMouseMove"
+    @mousemove="hasPointer && onMouseMove($event)"
     @click="openFullSize"
   >
     <img
@@ -14,15 +15,15 @@
       @error="$emit('error')"
     />
 
-    <!-- Magnifier lens -->
+    <!-- Magnifier lens (pointer devices only) -->
     <div
-      v-if="hovering && loaded"
+      v-if="hasPointer && hovering && loaded"
       class="zoom-lens"
       :style="lensStyle"
     />
 
-    <!-- Hint overlay -->
-    <div v-if="!hovering" class="zoom-hint">
+    <!-- Hint overlay (pointer devices only) -->
+    <div v-if="hasPointer && !hovering" class="zoom-hint">
       <svg
         class="w-5 h-5"
         fill="none"
@@ -55,6 +56,12 @@ defineEmits<{
 
 const ZOOM = props.zoomScale ?? 2.5;
 const LENS_SIZE = 160;
+
+// Detect fine pointer (mouse) vs coarse (touch)
+const hasPointer = ref(
+  typeof window !== 'undefined' &&
+    window.matchMedia('(pointer: fine)').matches
+);
 
 const containerRef = ref<HTMLElement | null>(null);
 const hovering = ref(false);
@@ -118,7 +125,11 @@ const lensStyle = computed(() => {
 
 <style scoped>
 .zoom-container {
-  @apply relative overflow-hidden cursor-zoom-in select-none;
+  @apply relative overflow-hidden select-none;
+}
+
+.zoom-container--pointer {
+  @apply cursor-zoom-in;
 }
 
 .zoom-image {

--- a/src/pages/annotate/_components/_location/Location.vue
+++ b/src/pages/annotate/_components/_location/Location.vue
@@ -1,18 +1,25 @@
 <template>
   <div>
-    <p>Location: {{ locationModel?.display_name }}</p>
-    <p>Location ID: {{ locationModel?.id }}</p>
-    <div class="grid grid-cols-1 gap-4">
-      <div class="col-auto">
-        <RadioForm
-          v-model="selectedRadioLocation"
-          :options="radioOptions"
-          header="Suggestions"
-          @update:model-value="handleRadioFormSelect"
-        />
-      </div>
+    <h3 class="view-heading">Select a location</h3>
+
+    <div v-if="locationModel" class="view-current">
+      <span class="view-current-label">Selected:</span>
+      <strong>{{ locationModel.display_name }}</strong>
     </div>
-    <SearchForm @update:model-value="handleSearchLocationSelect" />
+
+    <div v-if="radioOptions.length" class="view-suggestions">
+      <RadioForm
+        v-model="selectedRadioLocation"
+        :options="radioOptions"
+        header="Suggestions"
+        @update:model-value="handleRadioFormSelect"
+      />
+    </div>
+
+    <div class="view-search">
+      <h4 class="view-search-label">Or search for a location</h4>
+      <SearchForm @update:model-value="handleSearchLocationSelect" />
+    </div>
   </div>
 </template>
 
@@ -85,7 +92,7 @@ watch(resetKey, () => {
 //===================
 function handleRadioFormSelect(option: RadioOption) {
   locationModel.value = {
-    id: Number(option.value), // option.value is typed as String | Number
+    id: Number(option.value),
     display_name: option.display_name
   };
   emit('select', null);
@@ -104,3 +111,29 @@ function handleSearchLocationSelect(loc: LocationSuggestion) {
   emit('select', null);
 }
 </script>
+
+<style scoped>
+.view-heading {
+  @apply text-sm font-semibold text-wineneutral-600 uppercase tracking-wider mb-4;
+}
+
+.view-current {
+  @apply mb-4 text-sm bg-brand-wine-50 border border-brand-wine-200 rounded-lg px-3 py-2;
+}
+
+.view-current-label {
+  @apply text-wineneutral-500 mr-1;
+}
+
+.view-suggestions {
+  @apply mb-5 pb-5 border-b border-wineneutral-200;
+}
+
+.view-search {
+  @apply mt-2;
+}
+
+.view-search-label {
+  @apply text-xs font-bold text-wineneutral-500 uppercase tracking-wider mb-2;
+}
+</style>

--- a/src/pages/annotate/_components/_location/Location.vue
+++ b/src/pages/annotate/_components/_location/Location.vue
@@ -118,7 +118,7 @@ function handleSearchLocationSelect(loc: LocationSuggestion) {
 }
 
 .view-current {
-  @apply mb-4 text-sm bg-brand-wine-50 border border-brand-wine-200 rounded-lg px-3 py-2;
+  @apply mb-4 text-sm bg-amber-900/20 border border-amber-600 rounded-lg px-3 py-2 text-amber-100;
 }
 
 .view-current-label {

--- a/src/pages/annotate/_components/_location/Location.vue
+++ b/src/pages/annotate/_components/_location/Location.vue
@@ -118,7 +118,7 @@ function handleSearchLocationSelect(loc: LocationSuggestion) {
 }
 
 .view-current {
-  @apply mb-4 text-sm bg-amber-900/20 border border-amber-600 rounded-lg px-3 py-2 text-amber-100;
+  @apply mb-4 text-sm bg-goldneutral-900/20 border border-goldneutral-600 rounded-lg px-3 py-2 text-goldneutral-100;
 }
 
 .view-current-label {

--- a/src/pages/annotate/_components/_location/SearchLocationForm.vue
+++ b/src/pages/annotate/_components/_location/SearchLocationForm.vue
@@ -1,52 +1,44 @@
 <template>
-  <div class="px-4 mb-4 border-wineneutral-300 bg-wineneutral-50 border-2">
-    <div
-      class="col-span-1 flex flex-col mt-4 gap-4 @md:col-span-2 @lg:col-span-3 @md:flex-row @md:gap-0"
+  <div class="search-form">
+    <Typeahead
+      :id="TYPEAHEAD_ID"
+      ref="typeaheadRef"
+      :format-item-for-display="(item) => item.display_name"
+      :items="items"
+      :placeholder="placeholder ?? 'Enter a place'"
+      @select-item="handleSelectRecord"
+      @on-input="fetchTypeaheadResults"
     >
-      <Typeahead
-        :id="TYPEAHEAD_ID"
-        ref="typeaheadRef"
-        :format-item-for-display="(item) => item.display_name"
-        :items="items"
-        :placeholder="placeholder ?? 'Enter a place'"
-        @select-item="handleSelectRecord"
-        @on-input="fetchTypeaheadResults"
-      >
-        <!-- Pass label as slot to typeahead -->
-        <template #label>
-          <h4 class="uppercase">Search location</h4>
-        </template>
+      <!-- Pass label as slot to typeahead -->
+      <template #label>
+        <h4
+          class="text-xs font-bold text-wineneutral-500 uppercase tracking-wider"
+        >
+          Search location
+        </h4>
+      </template>
 
-        <!-- Item to render passed as scoped slot -->
-        <template #item="item">
-          <!-- eslint-disable-next-line vue/no-v-html This data is coming from our API, so we can trust it-->
-          <span v-html="typeaheadRef?.boldMatchText(item.display_name)" />
-          <span
-            class="border-2 border-neutral-700 dark:border-neutral-400 rounded-full text-neutral-700 dark:text-neutral-400 text-xs @md:text-sm px-2 py-1"
-          >
-            {{ item.type }}
-          </span>
-        </template>
-        <template #not-found>
-          <span>
-            We don't have agencies in the place you're looking for. Is it
-            spelled correctly? If our database is missing something, please
-            reach us at
-            <a href="mailto:contact@pdap.io">contact@pdap.io</a>
-          </span>
-        </template>
-      </Typeahead>
-      <!--TODO: This is a hacky fix to account for the fact that, without these, the suggestions disappear from the div-->
-      <br />
-      <br />
-      <br />
-      <br />
-      <br />
-      <br />
-      <br />
-      <br />
-      <br />
-    </div>
+      <!-- Item to render passed as scoped slot -->
+      <template #item="item">
+        <!-- eslint-disable-next-line vue/no-v-html This data is coming from our API, so we can trust it-->
+        <span v-html="typeaheadRef?.boldMatchText(item.display_name)" />
+        <span
+          class="border border-wineneutral-300 rounded-full text-wineneutral-600 text-xs px-2 py-0.5 ml-2"
+        >
+          {{ item.type }}
+        </span>
+      </template>
+
+      <template #not-found>
+        <span class="text-sm text-wineneutral-600">
+          We don't have agencies in the place you're looking for. Is it spelled
+          correctly? If our database is missing something, please reach us at
+          <a href="mailto:contact@pdap.io" class="font-semibold underline">
+            contact@pdap.io
+          </a>
+        </span>
+      </template>
+    </Typeahead>
   </div>
 </template>
 
@@ -105,7 +97,6 @@ const typeaheadMutation = useMutation({
   onSuccess: (data) => {
     items.value = data;
     // Update the query cache with the new data
-    // TODO: Would this interfere with the homepage typeahead?
     queryClient.setQueryData(queryKey, data, {
       staleTime: 5 * 60 * 1000
     });
@@ -147,3 +138,9 @@ function handleSelectRecord(item) {
   emit('update:modelValue', item);
 }
 </script>
+
+<style scoped>
+.search-form {
+  @apply rounded-lg border border-wineneutral-200 bg-wineneutral-50 p-4 min-h-[200px];
+}
+</style>

--- a/src/pages/annotate/_components/_name/EditableRadioGroup.vue
+++ b/src/pages/annotate/_components/_name/EditableRadioGroup.vue
@@ -186,7 +186,7 @@ const isDirty = (id): boolean => nameMapping[id].dirty;
 }
 
 .erg-item--selected {
-  @apply border-amber-500 bg-amber-900/20;
+  @apply border-brand-gold-500 bg-brand-gold-900/20;
 }
 
 .erg-radio {
@@ -194,11 +194,11 @@ const isDirty = (id): boolean => nameMapping[id].dirty;
 }
 
 .erg-item--selected .erg-radio {
-  @apply border-amber-500;
+  @apply border-brand-gold-500;
 }
 
 .erg-radio-dot {
-  @apply w-2.5 h-2.5 rounded-full bg-amber-500;
+  @apply w-2.5 h-2.5 rounded-full bg-brand-gold-500;
 }
 
 .erg-editable {
@@ -206,11 +206,11 @@ const isDirty = (id): boolean => nameMapping[id].dirty;
 }
 
 .erg-input {
-  @apply flex-1 text-sm bg-wineneutral-900 text-wineneutral-100 border border-amber-600 rounded-md px-3 py-1.5 outline-none focus:border-amber-400 focus:ring-1 focus:ring-amber-500/30;
+  @apply flex-1 text-sm bg-wineneutral-900 text-wineneutral-100 border border-brand-gold-600 rounded-md px-3 py-1.5 outline-none focus:border-brand-gold-400 focus:ring-1 focus:ring-brand-gold-500/30;
 }
 
 .erg-reset {
-  @apply text-amber-400 hover:text-amber-300 transition-colors p-1;
+  @apply text-brand-gold-400 hover:text-brand-gold-300 transition-colors p-1;
 }
 
 .erg-label {

--- a/src/pages/annotate/_components/_name/EditableRadioGroup.vue
+++ b/src/pages/annotate/_components/_name/EditableRadioGroup.vue
@@ -1,35 +1,44 @@
 <template>
-  <div class="space-y-2">
+  <div class="erg-list">
     <div
       v-for="option in options"
       :key="option.id"
-      class="flex items-center gap-2 border rounded-lg p-3 cursor-pointer transition hover:bg-purple-950"
-      :class="isSelected(option.id) ? 'ring-2  bg-orange-500' : ''"
+      class="erg-item"
+      :class="isSelected(option.id) ? 'erg-item--selected' : 'erg-item--default'"
       @click="choose(option)"
     >
-      <!-- Custom radio circle -->
-      <span
-        class="w-4 h-4 rounded-full border flex items-center justify-center shrink-0"
-      >
-        <span
-          v-if="isSelected(option.id)"
-          class="w-2 h-2 rounded-full bg-blue-500"
-        />
+      <!-- Radio circle -->
+      <span class="erg-radio">
+        <span v-if="isSelected(option.id)" class="erg-radio-dot" />
       </span>
 
       <!-- Label OR editable input -->
-      <span v-if="isSelected(option.id)">
+      <span v-if="isSelected(option.id)" class="erg-editable">
         <input
-          class="flex-1 text-black bg-white outline-none border-b border-dashed"
+          class="erg-input"
           :value="option.text"
           @click.stop
           @input="handleInput(option, $event)"
         />
-        <button @click="resetOption(option)">🔁</button>
+        <button class="erg-reset" @click.stop="resetOption(option)">
+          <svg
+            class="w-4 h-4"
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke="currentColor"
+            stroke-width="2"
+          >
+            <path
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              d="M16.023 9.348h4.992v-.001M2.985 19.644v-4.992m0 0h4.992m-4.993 0 3.181 3.183a8.25 8.25 0 0 0 13.803-3.7M4.031 9.865a8.25 8.25 0 0 1 13.803-3.7l3.181 3.182"
+            />
+          </svg>
+        </button>
       </span>
 
-      <span v-else class="flex-1">
-        <span>{{ option.text + ' ' }}</span>
+      <span v-else class="erg-label">
+        <span>{{ option.text }}</span>
         <AnnotationSpan
           v-if="!isDirty(option.id)"
           :labels="option.annoLabels"
@@ -162,3 +171,49 @@ const handleInput = (option: editableRadioOption, event) => {
 const isSelected = (id): boolean => props.modelValue?.nameID === id;
 const isDirty = (id): boolean => nameMapping[id].dirty;
 </script>
+
+<style scoped>
+.erg-list {
+  @apply space-y-2;
+}
+
+.erg-item {
+  @apply flex items-center gap-3 border-2 rounded-lg p-3 cursor-pointer transition-all duration-150;
+}
+
+.erg-item--default {
+  @apply border-wineneutral-200 bg-wineneutral-50 hover:border-brand-wine-300 hover:bg-wineneutral-100;
+}
+
+.erg-item--selected {
+  @apply border-brand-wine-500 bg-brand-wine-50;
+}
+
+.erg-radio {
+  @apply w-5 h-5 rounded-full border-2 border-wineneutral-400 flex items-center justify-center shrink-0;
+}
+
+.erg-item--selected .erg-radio {
+  @apply border-brand-wine-500;
+}
+
+.erg-radio-dot {
+  @apply w-2.5 h-2.5 rounded-full bg-brand-wine-500;
+}
+
+.erg-editable {
+  @apply flex-1 flex items-center gap-2;
+}
+
+.erg-input {
+  @apply flex-1 text-sm bg-white border border-wineneutral-300 rounded-md px-3 py-1.5 outline-none focus:border-brand-wine-400 focus:ring-1 focus:ring-brand-wine-200;
+}
+
+.erg-reset {
+  @apply text-wineneutral-400 hover:text-brand-wine-500 transition-colors p-1;
+}
+
+.erg-label {
+  @apply flex-1 flex items-center gap-2 text-sm;
+}
+</style>

--- a/src/pages/annotate/_components/_name/EditableRadioGroup.vue
+++ b/src/pages/annotate/_components/_name/EditableRadioGroup.vue
@@ -186,7 +186,7 @@ const isDirty = (id): boolean => nameMapping[id].dirty;
 }
 
 .erg-item--selected {
-  @apply border-brand-gold-500 bg-brand-gold-900/20;
+  @apply border-brand-wine-400 bg-brand-wine-900/20;
 }
 
 .erg-radio {
@@ -194,11 +194,11 @@ const isDirty = (id): boolean => nameMapping[id].dirty;
 }
 
 .erg-item--selected .erg-radio {
-  @apply border-brand-gold-500;
+  @apply border-brand-wine-400;
 }
 
 .erg-radio-dot {
-  @apply w-2.5 h-2.5 rounded-full bg-brand-gold-500;
+  @apply w-2.5 h-2.5 rounded-full bg-brand-wine-400;
 }
 
 .erg-editable {
@@ -206,11 +206,11 @@ const isDirty = (id): boolean => nameMapping[id].dirty;
 }
 
 .erg-input {
-  @apply flex-1 text-sm bg-wineneutral-900 text-wineneutral-100 border border-brand-gold-600 rounded-md px-3 py-1.5 outline-none focus:border-brand-gold-400 focus:ring-1 focus:ring-brand-gold-500/30;
+  @apply flex-1 text-sm bg-wineneutral-900 text-wineneutral-100 border border-wineneutral-600 rounded-md px-3 py-1.5 outline-none focus:border-brand-wine-400 focus:ring-1 focus:ring-brand-wine-400/30;
 }
 
 .erg-reset {
-  @apply text-brand-gold-400 hover:text-brand-gold-300 transition-colors p-1;
+  @apply text-wineneutral-400 hover:text-wineneutral-200 transition-colors p-1;
 }
 
 .erg-label {

--- a/src/pages/annotate/_components/_name/EditableRadioGroup.vue
+++ b/src/pages/annotate/_components/_name/EditableRadioGroup.vue
@@ -186,7 +186,7 @@ const isDirty = (id): boolean => nameMapping[id].dirty;
 }
 
 .erg-item--selected {
-  @apply border-brand-wine-500 bg-brand-wine-50;
+  @apply border-amber-500 bg-amber-900/20;
 }
 
 .erg-radio {
@@ -194,11 +194,11 @@ const isDirty = (id): boolean => nameMapping[id].dirty;
 }
 
 .erg-item--selected .erg-radio {
-  @apply border-brand-wine-500;
+  @apply border-amber-500;
 }
 
 .erg-radio-dot {
-  @apply w-2.5 h-2.5 rounded-full bg-brand-wine-500;
+  @apply w-2.5 h-2.5 rounded-full bg-amber-500;
 }
 
 .erg-editable {
@@ -206,11 +206,11 @@ const isDirty = (id): boolean => nameMapping[id].dirty;
 }
 
 .erg-input {
-  @apply flex-1 text-sm bg-white border border-wineneutral-300 rounded-md px-3 py-1.5 outline-none focus:border-brand-wine-400 focus:ring-1 focus:ring-brand-wine-200;
+  @apply flex-1 text-sm bg-wineneutral-900 text-wineneutral-100 border border-amber-600 rounded-md px-3 py-1.5 outline-none focus:border-amber-400 focus:ring-1 focus:ring-amber-500/30;
 }
 
 .erg-reset {
-  @apply text-wineneutral-400 hover:text-brand-wine-500 transition-colors p-1;
+  @apply text-amber-400 hover:text-amber-300 transition-colors p-1;
 }
 
 .erg-label {

--- a/src/pages/annotate/_components/_name/Name.vue
+++ b/src/pages/annotate/_components/_name/Name.vue
@@ -1,6 +1,12 @@
 <template>
   <div>
-    <p>{{ selected?.name }}</p>
+    <h3 class="view-heading">Name this data source</h3>
+
+    <div v-if="selected?.name" class="view-current">
+      <span class="view-current-label">Selected:</span>
+      <strong>{{ selected.name }}</strong>
+    </div>
+
     <EditableRadioGroup
       v-model="selected"
       :options="options"
@@ -76,3 +82,17 @@ function getNameEndorsementLabel(suggestion: NameSuggestion): AnnoLabels {
   };
 }
 </script>
+
+<style scoped>
+.view-heading {
+  @apply text-sm font-semibold text-wineneutral-600 uppercase tracking-wider mb-4;
+}
+
+.view-current {
+  @apply mb-4 text-sm bg-brand-wine-50 border border-brand-wine-200 rounded-lg px-3 py-2;
+}
+
+.view-current-label {
+  @apply text-wineneutral-500 mr-1;
+}
+</style>

--- a/src/pages/annotate/_components/_name/Name.vue
+++ b/src/pages/annotate/_components/_name/Name.vue
@@ -89,7 +89,7 @@ function getNameEndorsementLabel(suggestion: NameSuggestion): AnnoLabels {
 }
 
 .view-current {
-  @apply mb-4 text-sm bg-amber-900/20 border border-amber-600 rounded-lg px-3 py-2 text-amber-100;
+  @apply mb-4 text-sm bg-goldneutral-900/20 border border-goldneutral-600 rounded-lg px-3 py-2 text-goldneutral-100;
 }
 
 .view-current-label {

--- a/src/pages/annotate/_components/_name/Name.vue
+++ b/src/pages/annotate/_components/_name/Name.vue
@@ -89,7 +89,7 @@ function getNameEndorsementLabel(suggestion: NameSuggestion): AnnoLabels {
 }
 
 .view-current {
-  @apply mb-4 text-sm bg-brand-wine-50 border border-brand-wine-200 rounded-lg px-3 py-2;
+  @apply mb-4 text-sm bg-amber-900/20 border border-amber-600 rounded-lg px-3 py-2 text-amber-100;
 }
 
 .view-current-label {

--- a/src/pages/annotate/_components/_shared/AnnotationSpan.vue
+++ b/src/pages/annotate/_components/_shared/AnnotationSpan.vue
@@ -48,6 +48,6 @@ const props = defineProps<Props>();
 }
 
 .anno-badge--robo {
-  @apply bg-brand-gold-100 text-brand-gold-700;
+  @apply bg-goldneutral-100 text-goldneutral-700;
 }
 </style>

--- a/src/pages/annotate/_components/_shared/AnnotationSpan.vue
+++ b/src/pages/annotate/_components/_shared/AnnotationSpan.vue
@@ -1,19 +1,13 @@
 <template>
-  <span class="inline-flex gap-2">
-    <span
-      v-if="props?.labels?.user"
-      class="annotation user font-semibold text-wineneutral-300"
-    >
+  <span class="anno-badges">
+    <span v-if="props?.labels?.user" class="anno-badge anno-badge--user">
       {{ props.labels.user }}
-      <FontAwesomeIcon :icon="faUser" />
+      <FontAwesomeIcon :icon="faUser" class="w-3 h-3" />
     </span>
 
-    <span
-      v-if="props?.labels?.robo"
-      class="annotation robo font-semibold text-wineneutral-300"
-    >
+    <span v-if="props?.labels?.robo" class="anno-badge anno-badge--robo">
       {{ props.labels.robo }}
-      <FontAwesomeIcon :icon="faRobot" />
+      <FontAwesomeIcon :icon="faRobot" class="w-3 h-3" />
     </span>
   </span>
 </template>
@@ -39,3 +33,21 @@ type Props = {
 
 const props = defineProps<Props>();
 </script>
+
+<style scoped>
+.anno-badges {
+  @apply inline-flex gap-1.5;
+}
+
+.anno-badge {
+  @apply inline-flex items-center gap-1 text-xs font-semibold px-2 py-0.5 rounded-full;
+}
+
+.anno-badge--user {
+  @apply bg-wineneutral-100 text-wineneutral-600;
+}
+
+.anno-badge--robo {
+  @apply bg-brand-gold-100 text-brand-gold-700;
+}
+</style>

--- a/src/pages/annotate/_components/_shared/RadioForm.vue
+++ b/src/pages/annotate/_components/_shared/RadioForm.vue
@@ -1,31 +1,33 @@
 <template>
-  <h2>{{ props.header }}</h2>
-  <form id="id" name="name" class="pdap-form">
-    <div class="grid gap-4 pdap-input-radio-group">
-      <div
-        class="pdap-input pdap-input-radio"
+  <div>
+    <h4 v-if="props.header" class="rf-header">{{ props.header }}</h4>
+    <div class="rf-options">
+      <label
         v-for="option in options"
         :key="option.value"
+        :for="`option-${option.value}`"
+        class="rf-option"
+        :class="{ 'rf-option--selected': selectedType?.value === option.value }"
       >
         <input
           :id="`option-${option.value}`"
           v-model="selectedType"
           type="radio"
-          class="hidden"
+          class="sr-only"
           name="url-type"
           :value="option"
           @change="handleSelect(option)"
         />
-
-        <label :for="`option-${option.value}`" class="hover:text-amber-800">
-          <div class="font-semibold">
-            {{ option.label + ' ' }}
-            <AnnotationSpan :labels="option.anno_labels" />
-          </div>
-        </label>
-      </div>
+        <span class="rf-option-content">
+          <span class="rf-option-label">{{ option.label }}</span>
+          <AnnotationSpan
+            v-if="option.anno_labels?.user || option.anno_labels?.robo"
+            :labels="option.anno_labels"
+          />
+        </span>
+      </label>
     </div>
-  </form>
+  </div>
 </template>
 
 <script setup lang="ts">
@@ -69,3 +71,33 @@ function handleSelect(option: RadioOption) {
   emit('update:modelValue', option);
 }
 </script>
+
+<style scoped>
+.rf-header {
+  @apply text-xs font-bold text-wineneutral-500 uppercase tracking-wider mb-2;
+}
+
+.rf-options {
+  @apply space-y-1.5;
+}
+
+.rf-option {
+  @apply flex items-center rounded-lg px-3 py-2.5 cursor-pointer transition-all duration-150 border border-transparent;
+}
+
+.rf-option:hover {
+  @apply bg-wineneutral-100 border-wineneutral-200;
+}
+
+.rf-option--selected {
+  @apply bg-brand-wine-50 border-brand-wine-300;
+}
+
+.rf-option-content {
+  @apply flex items-center gap-2;
+}
+
+.rf-option-label {
+  @apply text-sm font-semibold;
+}
+</style>

--- a/src/pages/annotate/_components/_shared/RadioForm.vue
+++ b/src/pages/annotate/_components/_shared/RadioForm.vue
@@ -90,7 +90,7 @@ function handleSelect(option: RadioOption) {
 }
 
 .rf-option--selected {
-  @apply bg-brand-gold-900/30 border-brand-gold-500 text-brand-gold-100;
+  @apply bg-brand-wine-900/30 border-brand-wine-400 text-wineneutral-100;
 }
 
 .rf-option-content {

--- a/src/pages/annotate/_components/_shared/RadioForm.vue
+++ b/src/pages/annotate/_components/_shared/RadioForm.vue
@@ -90,7 +90,7 @@ function handleSelect(option: RadioOption) {
 }
 
 .rf-option--selected {
-  @apply bg-brand-wine-50 border-brand-wine-300;
+  @apply bg-amber-900/30 border-amber-500 text-amber-100;
 }
 
 .rf-option-content {

--- a/src/pages/annotate/_components/_shared/RadioForm.vue
+++ b/src/pages/annotate/_components/_shared/RadioForm.vue
@@ -90,7 +90,7 @@ function handleSelect(option: RadioOption) {
 }
 
 .rf-option--selected {
-  @apply bg-amber-900/30 border-amber-500 text-amber-100;
+  @apply bg-brand-gold-900/30 border-brand-gold-500 text-brand-gold-100;
 }
 
 .rf-option-content {

--- a/src/pages/annotate/index.vue
+++ b/src/pages/annotate/index.vue
@@ -41,33 +41,88 @@
             <!-- Left: URL Preview -->
             <aside class="annotate-preview">
               <div class="annotate-preview-card">
-                <div class="annotate-screenshot">
-                  <ZoomableImage
-                    v-if="imageOk"
-                    :key="localAnnotation.next_annotation?.url_info.url_id"
-                    :src="`${URL_BASE}/${localAnnotation.next_annotation?.url_info.url_id}/screenshot`"
-                    alt="Screenshot of URL Page"
-                    @error="imageOk = false"
-                  />
-                  <div v-else class="annotate-screenshot-fallback">
+                <!-- Mobile toggle bar (always visible on mobile) -->
+                <button
+                  class="preview-toggle"
+                  @click="previewExpanded = !previewExpanded"
+                >
+                  <div class="preview-toggle-left">
                     <svg
-                      xmlns="http://www.w3.org/2000/svg"
-                      class="w-8 h-8"
+                      class="w-4 h-4 shrink-0 text-wineneutral-400"
                       fill="none"
                       viewBox="0 0 24 24"
                       stroke="currentColor"
+                      stroke-width="1.5"
                     >
                       <path
                         stroke-linecap="round"
                         stroke-linejoin="round"
-                        stroke-width="1.5"
                         d="m2.25 15.75 5.159-5.159a2.25 2.25 0 0 1 3.182 0l5.159 5.159m-1.5-1.5 1.409-1.409a2.25 2.25 0 0 1 3.182 0l2.909 2.909M3.75 21h16.5A2.25 2.25 0 0 0 22.5 18.75V5.25A2.25 2.25 0 0 0 20.25 3H3.75A2.25 2.25 0 0 0 1.5 5.25v13.5A2.25 2.25 0 0 0 3.75 21Z"
                       />
                     </svg>
-                    <span>Image Not Found</span>
+                    <span class="preview-toggle-text">
+                      {{ previewExpanded ? 'Hide preview' : 'Show preview' }}
+                    </span>
+                  </div>
+                  <svg
+                    class="preview-toggle-chevron"
+                    :class="{ 'preview-toggle-chevron--open': previewExpanded }"
+                    fill="none"
+                    viewBox="0 0 24 24"
+                    stroke="currentColor"
+                    stroke-width="2"
+                  >
+                    <path
+                      stroke-linecap="round"
+                      stroke-linejoin="round"
+                      d="M19.5 8.25l-7.5 7.5-7.5-7.5"
+                    />
+                  </svg>
+                </button>
+
+                <!-- Expandable content (always visible on lg, toggle on mobile) -->
+                <div class="preview-body" :class="{ 'preview-body--collapsed': !previewExpanded }">
+                  <div class="preview-body-inner">
+                    <div class="annotate-screenshot">
+                      <ZoomableImage
+                        v-if="imageOk"
+                        :key="localAnnotation.next_annotation?.url_info.url_id"
+                        :src="`${URL_BASE}/${localAnnotation.next_annotation?.url_info.url_id}/screenshot`"
+                        alt="Screenshot of URL Page"
+                        @error="imageOk = false"
+                      />
+                      <div v-else class="annotate-screenshot-fallback">
+                        <svg
+                          xmlns="http://www.w3.org/2000/svg"
+                          class="w-8 h-8"
+                          fill="none"
+                          viewBox="0 0 24 24"
+                          stroke="currentColor"
+                        >
+                          <path
+                            stroke-linecap="round"
+                            stroke-linejoin="round"
+                            stroke-width="1.5"
+                            d="m2.25 15.75 5.159-5.159a2.25 2.25 0 0 1 3.182 0l5.159 5.159m-1.5-1.5 1.409-1.409a2.25 2.25 0 0 1 3.182 0l2.909 2.909M3.75 21h16.5A2.25 2.25 0 0 0 22.5 18.75V5.25A2.25 2.25 0 0 0 20.25 3H3.75A2.25 2.25 0 0 0 1.5 5.25v13.5A2.25 2.25 0 0 0 3.75 21Z"
+                          />
+                        </svg>
+                        <span>Image Not Found</span>
+                      </div>
+                    </div>
+
+                    <div class="annotate-meta">
+                      <Header
+                        :refresh-key="globalResetKey"
+                        :url-i-d="localAnnotation.next_annotation.url_info.url_id"
+                        :page-title="
+                          localAnnotation.next_annotation.html_info.title
+                        "
+                      />
+                    </div>
                   </div>
                 </div>
 
+                <!-- URL always visible (outside collapsible body) -->
                 <div class="annotate-url-info">
                   <a
                     :href="localAnnotation.next_annotation?.url_info.url"
@@ -77,16 +132,6 @@
                   >
                     {{ localAnnotation.next_annotation?.url_info.url }}
                   </a>
-                </div>
-
-                <div class="annotate-meta">
-                  <Header
-                    :refresh-key="globalResetKey"
-                    :url-i-d="localAnnotation.next_annotation.url_info.url_id"
-                    :page-title="
-                      localAnnotation.next_annotation.html_info.title
-                    "
-                  />
                 </div>
               </div>
             </aside>
@@ -257,6 +302,9 @@ const currentPathIndex = ref<number>(0);
 
 // Whether the image successfully loaded.
 const imageOk = ref<boolean>(true);
+
+// Whether the mobile preview card is expanded
+const previewExpanded = ref<boolean>(true);
 
 // Variables tracking selections of annotation components.
 const selectedURLType = ref<URLTypeSelection>(null);
@@ -553,10 +601,52 @@ function updateReminderCookie() {
   @apply rounded-xl border-2 border-wineneutral-200 bg-wineneutral-50 overflow-hidden;
 }
 
+/* Mobile preview toggle */
+.preview-toggle {
+  @apply flex lg:hidden items-center justify-between w-full px-4 py-3 bg-transparent border-none text-left cursor-pointer;
+}
+
+.preview-toggle-left {
+  @apply flex items-center gap-2;
+}
+
+.preview-toggle-text {
+  @apply text-xs font-semibold text-wineneutral-400 uppercase tracking-wider;
+}
+
+.preview-toggle-chevron {
+  @apply w-4 h-4 text-wineneutral-400 transition-transform duration-200;
+}
+
+.preview-toggle-chevron--open {
+  transform: rotate(180deg);
+}
+
+/* Collapsible preview body */
+.preview-body {
+  @apply grid;
+  grid-template-rows: 1fr;
+  transition: grid-template-rows 0.3s ease-in-out;
+}
+
+.preview-body--collapsed {
+  grid-template-rows: 0fr;
+}
+
+@media (min-width: 1024px) {
+  .preview-body--collapsed {
+    grid-template-rows: 1fr;
+  }
+}
+
+.preview-body-inner {
+  overflow: hidden;
+  min-height: 0;
+}
+
 .annotate-screenshot {
   @apply bg-wineneutral-100 flex items-center justify-center overflow-hidden;
-  /* Mobile: fixed aspect ratio. Desktop: expand to fill, capped at a sane max */
-  aspect-ratio: 16 / 9;
+  aspect-ratio: 4 / 3;
 }
 
 @media (min-width: 1024px) {
@@ -587,7 +677,7 @@ function updateReminderCookie() {
 }
 
 .annotate-content {
-  @apply mt-4 rounded-xl border-2 border-wineneutral-200 bg-wineneutral-50 p-5 sm:p-6 min-h-[320px];
+  @apply mt-4 rounded-xl border-2 border-wineneutral-200 bg-wineneutral-50 p-4 sm:p-6 min-h-[200px] lg:min-h-[320px];
 }
 
 .annotate-empty {

--- a/src/pages/annotate/index.vue
+++ b/src/pages/annotate/index.vue
@@ -665,7 +665,7 @@ function updateReminderCookie() {
 }
 
 .annotate-url-link {
-  @apply text-sm text-brand-gold-500 hover:text-brand-gold-400 underline underline-offset-2 break-all leading-relaxed transition-colors;
+  @apply text-sm text-goldneutral-700 hover:text-goldneutral-800 underline underline-offset-2 break-all leading-relaxed transition-colors;
 }
 
 .annotate-meta {

--- a/src/pages/annotate/index.vue
+++ b/src/pages/annotate/index.vue
@@ -42,12 +42,11 @@
             <aside class="annotate-preview">
               <div class="annotate-preview-card">
                 <div class="annotate-screenshot">
-                  <img
+                  <ZoomableImage
                     v-if="imageOk"
-                    alt="Screenshot of URL Page"
                     :key="localAnnotation.next_annotation?.url_info.url_id"
                     :src="`${URL_BASE}/${localAnnotation.next_annotation?.url_info.url_id}/screenshot`"
-                    class="w-full h-full object-cover object-top"
+                    alt="Screenshot of URL Page"
                     @error="imageOk = false"
                   />
                   <div v-else class="annotate-screenshot-fallback">
@@ -243,6 +242,7 @@ import {
 import SupplementalInfo from '@/pages/annotate/_components/_index/SupplementalInfo.vue';
 import Reminder from '@/pages/annotate/_components/_index/Reminder.vue';
 import Modal from '@/pages/annotate/_components/_index/Modal.vue';
+import ZoomableImage from '@/pages/annotate/_components/_index/ZoomableImage.vue';
 //====================
 //     Types
 //====================
@@ -554,7 +554,16 @@ function updateReminderCookie() {
 }
 
 .annotate-screenshot {
-  @apply aspect-video bg-wineneutral-100 flex items-center justify-center overflow-hidden;
+  @apply bg-wineneutral-100 flex items-center justify-center overflow-hidden;
+  /* Mobile: fixed aspect ratio. Desktop: expand to fill, capped at a sane max */
+  aspect-ratio: 16 / 9;
+}
+
+@media (min-width: 1024px) {
+  .annotate-screenshot {
+    aspect-ratio: unset;
+    max-height: 520px;
+  }
 }
 
 .annotate-screenshot-fallback {

--- a/src/pages/annotate/index.vue
+++ b/src/pages/annotate/index.vue
@@ -566,7 +566,7 @@ function updateReminderCookie() {
 }
 
 .annotate-url-link {
-  @apply text-sm text-brand-wine-600 hover:text-brand-wine-800 underline underline-offset-2 break-all leading-relaxed transition-colors;
+  @apply text-sm text-amber-500 hover:text-amber-400 underline underline-offset-2 break-all leading-relaxed transition-colors;
 }
 
 .annotate-meta {
@@ -578,7 +578,7 @@ function updateReminderCookie() {
 }
 
 .annotate-content {
-  @apply mt-4 rounded-xl border-2 border-wineneutral-200 bg-white p-5 sm:p-6 min-h-[320px];
+  @apply mt-4 rounded-xl border-2 border-wineneutral-200 bg-wineneutral-50 p-5 sm:p-6 min-h-[320px];
 }
 
 .annotate-empty {

--- a/src/pages/annotate/index.vue
+++ b/src/pages/annotate/index.vue
@@ -665,7 +665,7 @@ function updateReminderCookie() {
 }
 
 .annotate-url-link {
-  @apply text-sm text-amber-500 hover:text-amber-400 underline underline-offset-2 break-all leading-relaxed transition-colors;
+  @apply text-sm text-brand-gold-500 hover:text-brand-gold-400 underline underline-offset-2 break-all leading-relaxed transition-colors;
 }
 
 .annotate-meta {


### PR DESCRIPTION
https://github.com/Police-Data-Accessibility-Project/pdap.io/issues/405

## Summary
- **Two-panel layout**: Sticky screenshot preview on the left, annotation wizard on the right (stacks on mobile)
- **Stepper navigation**: Replaced basic tab bar with numbered circle stepper showing progress, completed/skipped states
- **Consistent amber accent theme**: All interactive/selected states use amber instead of wine for readability on dark backgrounds
- **Zoomable screenshot**: Hover magnifier on desktop (disabled on touch devices), click/tap to open full-size
- **Mobile optimizations**: Collapsible preview card, compact screenshot (4:3), reduced padding, single-column record type grid
- **Cleaned up**: Removed `<br>` spacer hacks, unified notice patterns, converted components to Composition API

## Test plan
- [ ] Verify two-panel layout on desktop (lg+ breakpoint)
- [ ] Verify single-column stacked layout on mobile
- [ ] Test collapsible preview toggle on mobile (smooth animation, URL stays visible)
- [ ] Test screenshot hover magnifier on desktop (lens follows mouse, click opens full-size)
- [ ] Confirm magnifier is disabled on touch devices (no lens, no hint icon, tap opens full-size)
- [ ] Walk through full annotation flow: URL Type → Location → Agency → Record Type → Name → Confirm
- [ ] Verify stepper shows correct states (active, completed, skipped, disabled)
- [ ] Check all selected states use amber (buttons, radio options, pills)
- [ ] Test content warning modal and cookie reminder dismissal
- [ ] Verify SupplementalInfo collapsible panel opens/closes

🤖 Generated with [Claude Code](https://claude.com/claude-code)