### PR TITLE
fix: use semver range for Node engine to fix DO build

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "vue-eslint-parser": "^9.0.0"
   },
   "engines": {
-    "node": "24.13.1"
+    "node": ">=24"
   },
   "browserslist": [
     "> 1%",


### PR DESCRIPTION
## Max Notes

Digital Ocean build was failing due to https://github.com/Police-Data-Accessibility-Project/pdap.io/pull/410 , so this resolves that issue.

## Summary
- Changes `engines.node` from exact version `"24.13.1"` to `">=24"`
- The exact version was not resolvable by the Digital Ocean Heroku buildpack, causing "No result" during the "Resolving Node version" step and failing the build

## Test plan
- [ ] Verify Digital Ocean build succeeds with the updated engine range
- [ ] Confirm local `npm run build` still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)