### PR TITLE
fix: mock email/password login in E2E tests

### DIFF
--- a/e2e/fixtures/constants.js
+++ b/e2e/fixtures/constants.js
@@ -1,4 +1,5 @@
 import dotenv from 'dotenv';
 dotenv.config();
 
+export const AUTH_BASE_URL = process.env.VITE_API_URL + '/auth';
 export const OAUTH_BASE_URL = process.env.VITE_API_URL + '/oauth';

--- a/e2e/mocks/handlers/auth.js
+++ b/e2e/mocks/handlers/auth.js
@@ -1,7 +1,8 @@
 import { http, HttpResponse } from 'msw';
 import jwt from 'jsonwebtoken';
 import { ENDPOINTS } from '../../../src/api/constants';
-import { OAUTH_BASE_URL as OAUTH_BASE } from '../../fixtures/constants';
+import { AUTH_BASE_URL as AUTH_BASE, OAUTH_BASE_URL as OAUTH_BASE } from '../../fixtures/constants';
+import { PASSWORD_AUTH } from '../../fixtures/users';
 
 const createTestTokens = () => {
   const secret = 'test-secret';
@@ -30,6 +31,24 @@ const createTestTokens = () => {
 };
 
 export const authHandlers = [
+  // Handler for email/password login
+  http.post(`${AUTH_BASE}/${ENDPOINTS.AUTH.LOGIN}`, async ({ request }) => {
+    const body = await request.json();
+
+    if (body.email === PASSWORD_AUTH.email && body.password === PASSWORD_AUTH.password) {
+      const { accessToken, refreshToken } = createTestTokens();
+      return HttpResponse.json(
+        { access_token: accessToken, refresh_token: refreshToken },
+        { status: 200 }
+      );
+    }
+
+    return HttpResponse.json(
+      { message: 'Invalid credentials' },
+      { status: 401 }
+    );
+  }),
+
   // Handler for GitHub OAuth redirect
   http.get(`${OAUTH_BASE}/${ENDPOINTS.OAUTH.GITHUB}`, ({ request }) => {
     const url = new URL(request.url);

--- a/e2e/mocks/handlers/auth.js
+++ b/e2e/mocks/handlers/auth.js
@@ -1,7 +1,10 @@
 import { http, HttpResponse } from 'msw';
 import jwt from 'jsonwebtoken';
 import { ENDPOINTS } from '../../../src/api/constants';
-import { AUTH_BASE_URL as AUTH_BASE, OAUTH_BASE_URL as OAUTH_BASE } from '../../fixtures/constants';
+import {
+  AUTH_BASE_URL as AUTH_BASE,
+  OAUTH_BASE_URL as OAUTH_BASE
+} from '../../fixtures/constants';
 import { PASSWORD_AUTH } from '../../fixtures/users';
 
 const createTestTokens = () => {
@@ -35,7 +38,10 @@ export const authHandlers = [
   http.post(`${AUTH_BASE}/${ENDPOINTS.AUTH.LOGIN}`, async ({ request }) => {
     const body = await request.json();
 
-    if (body.email === PASSWORD_AUTH.email && body.password === PASSWORD_AUTH.password) {
+    if (
+      body.email === PASSWORD_AUTH.email &&
+      body.password === PASSWORD_AUTH.password
+    ) {
       const { accessToken, refreshToken } = createTestTokens();
       return HttpResponse.json(
         { access_token: accessToken, refresh_token: refreshToken },


### PR DESCRIPTION
## Summary
- Adds an MSW handler for `POST /auth/login` that returns mock JWT tokens for valid credentials and 401 for invalid ones
- Exports `AUTH_BASE_URL` from `e2e/fixtures/constants.js` for the new handler
- Fixes #411

This eliminates the dependency on real API credentials and external API availability for auth-dependent E2E tests, addressing two failure modes:
1. **Fork PRs**: GitHub Actions doesn't expose secrets to fork PRs, causing all 22+ auth-dependent tests to fail
2. **Flaky timeouts**: Real `signInWithPassword` API calls sometimes exceed the 30s timeout

## Test plan
- [x] `npx playwright test e2e/auth/sign-in.spec.js` — all 5 tests pass
- [x] `npx playwright test e2e/data-request/create.spec.js e2e/data-source/create.spec.js` — 8/9 pass (1 pre-existing flaky failure from real `POST /data-requests` API, not auth-related)
- [x] Full suite shows no regressions from these changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)