### PR TITLE
fix: add aria-label to icon-only buttons and links (#311)

### DIFF
--- a/src/components/TypeaheadSelected.vue
+++ b/src/components/TypeaheadSelected.vue
@@ -3,7 +3,13 @@
     <p class="text">
       {{ content }}
     </p>
-    <Button class="button" intent="tertiary" type="button" @click="click">
+    <Button
+      class="button"
+      intent="tertiary"
+      type="button"
+      aria-label="Remove"
+      @click="click"
+    >
       <FontAwesomeIcon :icon="faMinus" />
     </Button>
   </div>

--- a/src/components/maps/DataSourceMapSidebar.vue
+++ b/src/components/maps/DataSourceMapSidebar.vue
@@ -9,6 +9,7 @@
         v-if="activeLocation"
         class="p-2 mr-3 flex items-center justify-center text-wineneutral-950 bg-wineneutral-300 hover:bg-wineneutral-300/90 focus:bg-wineneutral-300/90 dark:bg-goldneutral-400 dark:hover:bg-goldneutral-400/90 dark:focus:bg-goldneutral-400/90"
         intent="tertiary"
+        aria-label="Go back"
         @click="handleBackClick"
       >
         <FontAwesomeIcon :icon="faChevronLeft" />

--- a/src/pages/annotate/_components/_index/Modal.vue
+++ b/src/pages/annotate/_components/_index/Modal.vue
@@ -31,6 +31,7 @@
               <button
                 type="button"
                 class="text-wineneutral-500 hover:text-wineneutral-200 transition-colors p-1 hover:bg-wineneutral-800"
+                aria-label="Close"
                 @click="emitClose"
               >
                 <FontAwesomeIcon :icon="faXmark" class="w-5 h-5" />

--- a/src/pages/annotate/_components/_index/ZoomableImage.vue
+++ b/src/pages/annotate/_components/_index/ZoomableImage.vue
@@ -40,6 +40,7 @@
         viewBox="0 0 24 24"
         stroke="currentColor"
         stroke-width="1.5"
+        aria-hidden="true"
       >
         <path
           stroke-linecap="round"

--- a/src/pages/index.vue
+++ b/src/pages/index.vue
@@ -436,6 +436,7 @@
           <a
             href="https://docs.pdap.io/activities/terms-and-definitions/terminology"
             target="blank"
+            aria-label="Terminology definition"
           >
             <i class="fa fa-question-circle" />
           </a>

--- a/src/pages/portals/court-warrant/_CourtWarrantMapSidebar.vue
+++ b/src/pages/portals/court-warrant/_CourtWarrantMapSidebar.vue
@@ -8,6 +8,7 @@
         v-if="activeLocation"
         class="p-2 mr-3 flex items-center justify-center text-wineneutral-950 bg-wineneutral-300 hover:bg-wineneutral-300/90 focus:bg-wineneutral-300/90 dark:bg-goldneutral-400 dark:hover:bg-goldneutral-400/90 dark:focus:bg-goldneutral-400/90"
         intent="tertiary"
+        aria-label="Go back"
         @click="handleBackClick"
       >
         <FontAwesomeIcon :icon="faChevronLeft" />

--- a/src/pages/profile/_components/APIKey.vue
+++ b/src/pages/profile/_components/APIKey.vue
@@ -12,6 +12,7 @@
           v-if="onDismiss"
           class="h-max p-0 hover:brightness-95 max-w-max py-1 px-2"
           intent="tertiary"
+          aria-label="Dismiss"
           :data-test="TEST_IDS.profile_api_key_dismiss"
           @click="onDismiss"
         >
@@ -22,6 +23,7 @@
         <Button
           class="h-max p-0 hover:brightness-95 text-left max-w-full rounded"
           intent="tertiary"
+          :aria-label="copied ? 'Copied' : 'Copy API key'"
           :data-test="TEST_IDS.profile_api_key_copy"
           @click="copyToClipboard"
         >


### PR DESCRIPTION
  ## Summary

  Closes #311

  Adds `aria-label` attributes to icon-only interactive elements (buttons and links) so
  screen readers can announce their purpose. Also marks a decorative SVG as
  `aria-hidden`.

  ### Changes

  **Icon-only buttons/links (high priority):**
  - `APIKey.vue` — `aria-label="Dismiss"` on close button; dynamic `:aria-label` (`"Copy
  API key"` / `"Copied"`) on copy button
  - `TypeaheadSelected.vue` — `aria-label="Remove"` on minus button
  - `DataSourceMapSidebar.vue` — `aria-label="Go back"` on back button
  - `_CourtWarrantMapSidebar.vue` — `aria-label="Go back"` on back button
  - `Modal.vue` — `aria-label="Close"` on X button

  **Decorative/supplemental (medium priority):**
  - `ZoomableImage.vue` — `aria-hidden="true"` on decorative magnifier SVG
  - `index.vue` — `aria-label="Terminology definition"` on icon-only link

  ## Test plan

  - [ ] Run unit tests (`npm run test:unit`) — all 30 pass
  - [ ] Navigate to Profile page → verify dismiss and copy buttons are announced by
  screen reader
  - [ ] Navigate to Search map → verify back button is announced
  - [ ] Navigate to Court Warrant map → verify back button is announced
  - [ ] Navigate to Annotate page → verify modal close button and zoom hint SVG are
  correct
  - [ ] Navigate to Home page → verify terminology link is announced

  🤖 Generated with [Claude Code](https://claude.com/claude-code)