### PR TITLE
fix: allow GitHub OAuth users to change password

### DIFF
--- a/src/pages/__tests__/change-password.test.js
+++ b/src/pages/__tests__/change-password.test.js
@@ -1,0 +1,66 @@
+import { mount } from '@vue/test-utils';
+import { describe, expect, it, vi } from 'vitest';
+import ChangePassword from '../change-password.vue';
+import { createTestingPinia } from '@pinia/testing';
+import { VueQueryPlugin, QueryClient } from '@tanstack/vue-query';
+
+vi.mock('vue-router', async () => {
+  const actual = await vi.importActual('vue-router');
+  return {
+    ...actual,
+    useRouter: vi.fn(() => ({
+      push: vi.fn()
+    }))
+  };
+});
+
+vi.mock('@/api/user', () => ({
+  changePassword: vi.fn()
+}));
+
+vi.mock('vue3-toastify', () => ({
+  toast: { success: vi.fn() }
+}));
+
+function mountComponent() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } }
+  });
+
+  return mount(ChangePassword, {
+    global: {
+      plugins: [createTestingPinia(), [VueQueryPlugin, { queryClient }]],
+      stubs: {
+        PasswordValidationChecker: {
+          template: '<div data-test="password-checker-stub" />',
+          methods: {
+            updatePasswordValidation: vi.fn(),
+            isPasswordValid: vi.fn(() => true)
+          }
+        }
+      }
+    }
+  });
+}
+
+describe('ChangePassword', () => {
+  it('renders the password change form unconditionally', () => {
+    const wrapper = mountComponent();
+    expect(wrapper.find('[data-test="change-password-form"]').exists()).toBe(
+      true
+    );
+  });
+
+  it('renders all three password inputs', () => {
+    const wrapper = mountComponent();
+    const inputs = wrapper.findAll('input[type="password"]');
+    expect(inputs.length).toBe(3);
+  });
+
+  it('renders the submit button', () => {
+    const wrapper = mountComponent();
+    expect(wrapper.find('[data-test="change-password-submit"]').exists()).toBe(
+      true
+    );
+  });
+});

--- a/src/pages/change-password.vue
+++ b/src/pages/change-password.vue
@@ -13,61 +13,46 @@
   >
     <h1>Change your password</h1>
 
-    <!-- GH auth user - no password to change -->
-    <template v-if="profileData?.external_accounts.github">
-      <p>
-        You signed up with a GitHub account linked to the email address you
-        provided. No password is necessary to access your account.
-      </p>
-      <p>
-        {{ error?.message ?? passwordMatchError }}
-      </p>
-    </template>
+    <FormV2
+      id="change-password"
+      class="flex flex-col gap-2"
+      :data-test="TEST_IDS.change_password_form"
+      name="change-password"
+      :error="error?.message ?? passwordMatchError"
+      :schema="VALIDATION_SCHEMA"
+      @change="onChange"
+      @submit="updatePassword"
+      @input="onInput"
+    >
+      <InputPassword
+        v-for="input of INPUTS"
+        v-bind="{ ...input }"
+        :key="input.name"
+      />
 
-    <!-- Otherwise, allow change PW -->
-    <template v-else>
-      <FormV2
-        id="change-password"
-        class="flex flex-col gap-2"
-        :data-test="TEST_IDS.change_password_form"
-        name="change-password"
-        :error="error?.message ?? passwordMatchError"
-        :schema="VALIDATION_SCHEMA"
-        @change="onChange"
-        @submit="updatePassword"
-        @input="onInput"
+      <PasswordValidationChecker ref="passwordRef" class="mt-2" />
+
+      <Button
+        class="max-w-full"
+        :data-test="TEST_IDS.change_password_submit"
+        :disabled="isLoading"
+        :is-loading="isLoading"
+        type="submit"
       >
-        <InputPassword
-          v-for="input of INPUTS"
-          v-bind="{ ...input }"
-          :key="input.name"
-        />
-
-        <PasswordValidationChecker ref="passwordRef" class="mt-2" />
-
-        <Button
-          class="max-w-full"
-          :data-test="TEST_IDS.change_password_submit"
-          :disabled="isLoading"
-          :is-loading="isLoading"
-          type="submit"
-        >
-          Change password
-        </Button>
-      </FormV2>
-    </template>
+        Change password
+      </Button>
+    </FormV2>
   </main>
 </template>
 
 <script setup>
 import { Button, FormV2, InputPassword } from 'pdap-design-system';
-import { useMutation, useQuery } from '@tanstack/vue-query';
+import { useMutation } from '@tanstack/vue-query';
 import { toast } from 'vue3-toastify';
 import PasswordValidationChecker from '@/components/PasswordValidationChecker.vue';
 import { ref } from 'vue';
-import { changePassword, getUser } from '@/api/user';
+import { changePassword } from '@/api/user';
 import { useRouter } from 'vue-router';
-import { PROFILE } from '@/util/queryKeys';
 import { TEST_IDS } from '../../e2e/fixtures/test-ids';
 
 const router = useRouter();
@@ -136,22 +121,6 @@ const VALIDATION_SCHEMA = [
     }
   }
 ];
-const {
-  data: profileData
-  // error: profileError,
-  // isLoading: profileLoading,
-  // refetch: refetchProfile
-} = useQuery({
-  queryKey: [PROFILE],
-  queryFn: async () => {
-    const response = await getUser();
-    return response.data.data;
-  },
-  staleTime: 5 * 60 * 1000, // 5 minutes
-  onError: (err) => {
-    console.error(err);
-  }
-});
 
 const {
   error,


### PR DESCRIPTION
## Summary
- Removes the OAuth gating on `/change-password` that blocked GitHub-linked users from seeing the password change form
- Users who signed up with email first and later linked GitHub can now change their password
- Cleans up unused `useQuery`/`getUser`/`PROFILE` imports that were only needed for the OAuth check

Closes #279

## Test plan
- [ ] Log in with a GitHub-linked account — confirm the password change form is visible
- [ ] Log in with an email/password account — confirm the form still works as before
- [ ] All existing unit tests pass (`npx vitest run`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)