### PR TITLE
feat: add static Open Graph meta tags for social media previews

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,6 +8,12 @@
       name="description"
       content="Explore our database to see what kind of data is published about any police system in the United States. Find misconduct, budgets, and more."
     />
+    <meta property="og:site_name" content="PDAP" />
+    <meta property="og:title" content="Police Data Accessibility Project" />
+    <meta property="og:type" content="website" />
+    <meta property="og:description" content="Data and tools for answering questions about any police system in the United States" />
+    <meta property="og:image" content="/assets/favicon.png" />
+    <meta property="og:url" content="https://pdap.io" />
     <meta
       name="keywords"
       content="police data, public records, open data, police transparency, police oversight"

--- a/src/components/SearchForm.vue
+++ b/src/components/SearchForm.vue
@@ -166,9 +166,9 @@ const hasUpdatedCategories = ref(false);
 const hasLocation = computed(() =>
   Boolean(
     selectedRecord.value ||
-    initiallySearchedRecord.value ||
-    searchStore.activeLocation?.location_id ||
-    route.query.location_id
+      initiallySearchedRecord.value ||
+      searchStore.activeLocation?.location_id ||
+      route.query.location_id
   )
 );
 

--- a/src/components/maps/DataSourceMapSidebar.vue
+++ b/src/components/maps/DataSourceMapSidebar.vue
@@ -460,8 +460,8 @@ const followStatusQueryKey = computed(() => [
 const followStatusQueryEnabled = computed(() =>
   Boolean(
     activeLocationId.value &&
-    auth.isAuthenticated() &&
-    getIsV2FeatureEnabled('ENHANCED_SEARCH')
+      auth.isAuthenticated() &&
+      getIsV2FeatureEnabled('ENHANCED_SEARCH')
   )
 );
 

--- a/src/util/routeHelpers.js
+++ b/src/util/routeHelpers.js
@@ -6,12 +6,12 @@ const DEFAULT_META_TAGS = new Map([
     'description',
     'Data and tools for answering questions about any police system in the United States'
   ],
-  ['title', 'Police Data Access Point'],
+  ['title', 'Police Data Accessibility Project'],
   [
     'og:description',
     'Data and tools for answering questions about any police system in the United States'
   ],
-  ['og:title', 'Police Data Access Point'],
+  ['og:title', 'Police Data Accessibility Project'],
   ['og:type', 'website'],
   ['og:site_name', 'PDAP'],
   ['og:image', acronym]
@@ -52,10 +52,15 @@ function getNearestRouteByMetaProperty(to, property) {
  * @param {RouteLocationNormalized} nearestRouteWithMeta nearest route to `to` that has a meta tag defined
  */
 function refreshMetaTags(to, nearestRouteWithMeta) {
-  // Remove current tags
+  // Remove JS-managed tags from previous route
   Array.from(document.querySelectorAll('[data-controlled-meta]')).forEach(
     (el) => el.parentNode.removeChild(el)
   );
+
+  // Remove static OG tags from index.html so JS-managed tags replace them
+  Array.from(document.querySelectorAll('meta[property^="og:"]'))
+    .filter((el) => !el.hasAttribute('data-controlled-meta'))
+    .forEach((el) => el.parentNode.removeChild(el));
 
   META_PROPERTIES.filter((prop) => prop !== 'title')
     .map((prop) => {

--- a/vite.config.mjs
+++ b/vite.config.mjs
@@ -106,11 +106,11 @@ const ROUTES_TO_META = new Map([
   [
     "/",
     {
-      title: "Police Data Access Point - Search",
+      title: "Police Data Accessibility Project - Search",
       metaTags: [
         {
           property: "og:title",
-          title: "Police Data Access Point - Search",
+          title: "Police Data Accessibility Project - Search",
         },
       ],
     },


### PR DESCRIPTION
## Summary

- Add static OG meta tags (`og:site_name`, `og:title`, `og:type`, `og:description`, `og:image`, `og:url`) to `index.html` so social media crawlers that don't execute JavaScript see proper previews
- Fix default `og:title` from "Police Data Access Point" to "Police Data Accessibility Project" in `routeHelpers.js` and `vite.config.mjs`
- Update `refreshMetaTags` to remove static OG tags from `index.html` when JS takes over, preventing duplicates

Closes #173

## Test plan

- [ ] Run `npm run dev` and view page source (not inspect) to confirm static OG tags appear in raw HTML
- [ ] Inspect `<head>` in dev tools — OG tags should be present and managed by JS after load
- [ ] Navigate between routes and verify OG tags update dynamically without duplicates
- [ ] Validate with a social media preview tool (e.g. https://www.opengraph.xyz/)
- [ ] `npm run test:unit` passes (30/30)

🤖 Generated with [Claude Code](https://claude.com/claude-code)