### PR TITLE
fix: reduce E2E test flakiness by mocking unmocked endpoints

### DIFF
--- a/e2e/fixtures/constants.js
+++ b/e2e/fixtures/constants.js
@@ -3,3 +3,10 @@ dotenv.config();
 
 export const AUTH_BASE_URL = process.env.VITE_API_URL + '/auth';
 export const OAUTH_BASE_URL = process.env.VITE_API_URL + '/oauth';
+export const DATA_REQUESTS_BASE_URL = process.env.VITE_API_URL + '/data-requests';
+export const USER_BASE_V3_URL = process.env.VITE_API_URL_V3 + '/user';
+
+export const TEST_USER = {
+  id: 'test-user-id',
+  email: 'test_user@example.com'
+};

--- a/e2e/fixtures/constants.js
+++ b/e2e/fixtures/constants.js
@@ -3,7 +3,8 @@ dotenv.config();
 
 export const AUTH_BASE_URL = process.env.VITE_API_URL + '/auth';
 export const OAUTH_BASE_URL = process.env.VITE_API_URL + '/oauth';
-export const DATA_REQUESTS_BASE_URL = process.env.VITE_API_URL + '/data-requests';
+export const DATA_REQUESTS_BASE_URL =
+  process.env.VITE_API_URL + '/data-requests';
 export const USER_BASE_V3_URL = process.env.VITE_API_URL_V3 + '/user';
 
 export const TEST_USER = {

--- a/e2e/mocks/handlers/auth.js
+++ b/e2e/mocks/handlers/auth.js
@@ -56,6 +56,11 @@ export const authHandlers = [
     );
   }),
 
+  // Handler for API key generation
+  http.post(`${AUTH_BASE}/${ENDPOINTS.AUTH.API_KEY}`, () =>
+    HttpResponse.json({ api_key: 'test-api-key-abc123' }, { status: 200 })
+  ),
+
   // Handler for GitHub OAuth redirect
   http.get(`${OAUTH_BASE}/${ENDPOINTS.OAUTH.GITHUB}`, ({ request }) => {
     const url = new URL(request.url);

--- a/e2e/mocks/handlers/auth.js
+++ b/e2e/mocks/handlers/auth.js
@@ -3,7 +3,8 @@ import jwt from 'jsonwebtoken';
 import { ENDPOINTS } from '../../../src/api/constants';
 import {
   AUTH_BASE_URL as AUTH_BASE,
-  OAUTH_BASE_URL as OAUTH_BASE
+  OAUTH_BASE_URL as OAUTH_BASE,
+  TEST_USER
 } from '../../fixtures/constants';
 import { PASSWORD_AUTH } from '../../fixtures/users';
 
@@ -12,9 +13,9 @@ const createTestTokens = () => {
 
   const accessToken = jwt.sign(
     {
-      sub: 'test-user-id',
-      email: 'test@example.com',
-      name: 'Test User',
+      sub: TEST_USER.id,
+      // auth store reads `user_email` (not `email`) — see src/stores/auth.js
+      user_email: TEST_USER.email,
       exp: Math.floor(Date.now() / 1000) + 60 * 60, // 1 hour from now
       iat: Math.floor(Date.now() / 1000)
     },
@@ -23,7 +24,7 @@ const createTestTokens = () => {
 
   const refreshToken = jwt.sign(
     {
-      sub: 'test-user-id',
+      sub: TEST_USER.id,
       exp: Math.floor(Date.now() / 1000) + 7 * 24 * 60 * 60, // 7 days from now
       iat: Math.floor(Date.now() / 1000)
     },

--- a/e2e/mocks/handlers/data-requests.js
+++ b/e2e/mocks/handlers/data-requests.js
@@ -1,0 +1,11 @@
+import { http, HttpResponse } from 'msw';
+import { DATA_REQUESTS_BASE_URL } from '../../fixtures/constants';
+
+export const dataRequestHandlers = [
+  http.post(DATA_REQUESTS_BASE_URL, () =>
+    HttpResponse.json(
+      { id: 'mock-data-request-id', message: 'Data request created' },
+      { status: 200 }
+    )
+  )
+];

--- a/e2e/mocks/handlers/index.js
+++ b/e2e/mocks/handlers/index.js
@@ -1,3 +1,9 @@
 import { authHandlers } from './auth';
+import { dataRequestHandlers } from './data-requests';
+import { userHandlers } from './user';
 
-export const handlers = [...authHandlers];
+export const handlers = [
+  ...authHandlers,
+  ...dataRequestHandlers,
+  ...userHandlers
+];

--- a/e2e/mocks/handlers/user.js
+++ b/e2e/mocks/handlers/user.js
@@ -1,0 +1,18 @@
+import { http, HttpResponse } from 'msw';
+import { TEST_USER, USER_BASE_V3_URL } from '../../fixtures/constants';
+
+const emptyProfile = {
+  id: TEST_USER.id,
+  email: TEST_USER.email,
+  external_accounts: { github: null },
+  permissions: [],
+  followed_searches: [],
+  recent_searches: [],
+  data_requests: []
+};
+
+export const userHandlers = [
+  http.get(`${USER_BASE_V3_URL}/:id`, () =>
+    HttpResponse.json(emptyProfile, { status: 200 })
+  )
+];

--- a/src/components/SearchForm.vue
+++ b/src/components/SearchForm.vue
@@ -166,9 +166,9 @@ const hasUpdatedCategories = ref(false);
 const hasLocation = computed(() =>
   Boolean(
     selectedRecord.value ||
-      initiallySearchedRecord.value ||
-      searchStore.activeLocation?.location_id ||
-      route.query.location_id
+    initiallySearchedRecord.value ||
+    searchStore.activeLocation?.location_id ||
+    route.query.location_id
   )
 );
 

--- a/src/components/maps/DataSourceMapSidebar.vue
+++ b/src/components/maps/DataSourceMapSidebar.vue
@@ -461,8 +461,8 @@ const followStatusQueryKey = computed(() => [
 const followStatusQueryEnabled = computed(() =>
   Boolean(
     activeLocationId.value &&
-      auth.isAuthenticated() &&
-      getIsV2FeatureEnabled('ENHANCED_SEARCH')
+    auth.isAuthenticated() &&
+    getIsV2FeatureEnabled('ENHANCED_SEARCH')
   )
 );
 

--- a/src/pages/index.vue
+++ b/src/pages/index.vue
@@ -204,10 +204,7 @@
         Adding them to our database makes them more accessible to everyone.
       </p>
       <div class="flex-row">
-        <router-link
-          class="mt-2 pdap-button-primary"
-          :to="'/annotate'"
-        >
+        <router-link class="mt-2 pdap-button-primary" :to="'/annotate'">
           Help add Data Sources to our database
         </router-link>
         <router-link


### PR DESCRIPTION
## Summary

Resolves the flaky E2E failures tracked in #425.

**Root cause**: `e2e/mocks/handlers/index.js` only registered `authHandlers`. Every other API call (`GET /user/:id`, `POST /data-requests`, etc.) fell through MSW's `onUnhandledRequest: 'bypass'` and hit the real dev/prod backend, whose latency and availability drove the flakes. Three specs failed repeatedly across recent CI runs for exactly this reason:

- `e2e/auth/sign-in.spec.js` — post-login redirect
- `e2e/data-request/create.spec.js` — `waitForResponse` on `POST /data-requests`
- `e2e/profile/index.spec.js` — `[data-test=profile_email]` never became visible because `GET /user/:id` was unmocked

This PR:

- Adds MSW handlers for `GET ${VITE_API_URL_V3}/user/:id` and `POST ${VITE_API_URL}/data-requests`.
- Exports `USER_BASE_V3_URL`, `DATA_REQUESTS_BASE_URL`, and a shared `TEST_USER` constant from `e2e/fixtures/constants.js`.
- Fixes a JWT-claim mismatch in the existing auth mock: the access token emitted the `email` claim, but `src/stores/auth.js:56` reads `accessTokenParsed.user_email` — so `user.email` was undefined after a mocked sign-in. Now emits `user_email`.

Builds on #413, which mocked the login endpoint itself but didn't cover the downstream fetches that auth-dependent tests also need.

## Test plan

- [ ] CI E2E job green on this PR
- [ ] Re-run the CI a few times to confirm the previously flaky specs stay green
- [ ] Manual: `npx playwright test e2e/profile/index.spec.js e2e/data-request/create.spec.js e2e/auth/sign-in.spec.js`

Closes #425