### PR TITLE
feat: URL health pill on data source details (#421)

### DIFF
--- a/e2e/fixtures/test-ids.js
+++ b/e2e/fixtures/test-ids.js
@@ -46,6 +46,8 @@ export const TEST_IDS = {
   data_source_title: 'data-source-title',
   data_source_description: 'data-source-description',
   data_source_url: 'data-source-url',
+  data_source_url_health: 'data-source-url-health',
+  data_source_url_archive: 'data-source-url-archive',
   prev_next_nav: 'prev-next-nav',
   prev_button: 'prev-button',
   next_button: 'next-button',

--- a/src/pages/data-sources/[id].vue
+++ b/src/pages/data-sources/[id].vue
@@ -173,16 +173,22 @@
                 </div>
               </template>
             </div>
-            <a
-              :href="dataSource.source_url"
-              :data-test="TEST_IDS.data_source_url"
-              class="pdap-button-primary py-3 px-4 h-max mr-4"
-              target="_blank"
-              rel="noreferrer"
-            >
-              Visit Data Source
-              <FontAwesomeIcon :icon="faLink" />
-            </a>
+            <div class="flex flex-wrap gap-3 items-center">
+              <a
+                :href="dataSource.source_url"
+                :data-test="TEST_IDS.data_source_url"
+                class="pdap-button-primary py-3 px-4 h-max mr-4"
+                target="_blank"
+                rel="noreferrer"
+              >
+                Visit Data Source
+                <FontAwesomeIcon :icon="faLink" />
+              </a>
+              <UrlHealthPill
+                :url-status="dataSource.url_status"
+                :archive-url="dataSource.internet_archive_url"
+              />
+            </div>
           </div>
 
           <!-- Sections -->
@@ -243,6 +249,7 @@
 <script setup>
 import { Button, RecordTypeIcon, Spinner } from 'pdap-design-system';
 import PrevNextNav from './_components/Nav.vue';
+import UrlHealthPill from './_components/UrlHealthPill.vue';
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
 import { faLink } from '@fortawesome/free-solid-svg-icons';
 import { useSearchStore } from '@/stores/search';

--- a/src/pages/data-sources/_components/UrlHealthPill.vue
+++ b/src/pages/data-sources/_components/UrlHealthPill.vue
@@ -1,0 +1,86 @@
+<template>
+  <div v-if="status" class="flex flex-wrap gap-2 items-center">
+    <span
+      :class="['url-health-pill', status.tone]"
+      :data-test="TEST_IDS.data_source_url_health"
+      :title="status.tooltip"
+    >
+      <FontAwesomeIcon :icon="status.icon" />
+      <span>{{ status.label }}</span>
+    </span>
+    <a
+      v-if="status.key === 'archived' && archiveUrl"
+      :href="archiveUrl"
+      class="text-sm underline"
+      target="_blank"
+      rel="noreferrer"
+      :data-test="TEST_IDS.data_source_url_archive"
+    >
+      View archived copy
+    </a>
+  </div>
+</template>
+
+<script setup>
+import { computed } from 'vue';
+import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
+import {
+  faCircleCheck,
+  faBoxArchive,
+  faTriangleExclamation
+} from '@fortawesome/free-solid-svg-icons';
+import { TEST_IDS } from '../../../../e2e/fixtures/test-ids';
+
+const props = defineProps({
+  urlStatus: { type: String, default: null },
+  archiveUrl: { type: String, default: null }
+});
+
+const status = computed(() => {
+  const raw = props.urlStatus?.toLowerCase?.() ?? null;
+  if (raw === 'ok') {
+    return {
+      key: 'ok',
+      tone: 'tone-ok',
+      icon: faCircleCheck,
+      label: 'URL healthy',
+      tooltip: 'This source URL was reachable the last time we checked.'
+    };
+  }
+  if (raw === 'broken' && props.archiveUrl) {
+    return {
+      key: 'archived',
+      tone: 'tone-archived',
+      icon: faBoxArchive,
+      label: 'Archived copy available',
+      tooltip:
+        'The source URL is currently unreachable, but an archived copy exists.'
+    };
+  }
+  if (raw === 'broken') {
+    return {
+      key: 'broken',
+      tone: 'tone-broken',
+      icon: faTriangleExclamation,
+      label: 'URL broken',
+      tooltip: 'This source URL was not reachable the last time we checked.'
+    };
+  }
+  return null;
+});
+</script>
+
+<style scoped>
+.url-health-pill {
+  @apply inline-flex items-center gap-2 rounded-full px-3 py-1 border border-solid text-sm font-medium;
+}
+.tone-ok {
+  @apply bg-green-100 border-green-300 text-green-900 dark:bg-green-900 dark:border-green-700 dark:text-green-100;
+}
+.tone-archived {
+  @apply bg-amber-100 border-amber-300 text-amber-900 dark:bg-amber-900 dark:border-amber-700 dark:text-amber-100;
+}
+.tone-broken {
+  @apply bg-red-100 border-red-300 text-red-900 dark:bg-red-900 dark:border-red-700 dark:text-red-100;
+}
+</style>

--- a/src/pages/data-sources/_components/__tests__/UrlHealthPill.test.js
+++ b/src/pages/data-sources/_components/__tests__/UrlHealthPill.test.js
@@ -1,0 +1,66 @@
+import UrlHealthPill from '../UrlHealthPill.vue';
+import { mount } from '@vue/test-utils';
+import { describe, expect, it } from 'vitest';
+import { TEST_IDS } from '../../../../../e2e/fixtures/test-ids';
+
+describe('UrlHealthPill', () => {
+  it('renders nothing when status is missing', () => {
+    const wrapper = mount(UrlHealthPill, {
+      props: { urlStatus: null, archiveUrl: null }
+    });
+    expect(
+      wrapper.find(`[data-test="${TEST_IDS.data_source_url_health}"]`).exists()
+    ).toBe(false);
+  });
+
+  it('renders healthy state for "ok"', () => {
+    const wrapper = mount(UrlHealthPill, {
+      props: { urlStatus: 'ok', archiveUrl: null }
+    });
+    const pill = wrapper.find(
+      `[data-test="${TEST_IDS.data_source_url_health}"]`
+    );
+    expect(pill.exists()).toBe(true);
+    expect(pill.text()).toContain('URL healthy');
+    expect(pill.classes()).toContain('tone-ok');
+  });
+
+  it('renders archived state when broken and archive url present', () => {
+    const wrapper = mount(UrlHealthPill, {
+      props: { urlStatus: 'broken', archiveUrl: 'https://web.archive.org/abc' }
+    });
+    const pill = wrapper.find(
+      `[data-test="${TEST_IDS.data_source_url_health}"]`
+    );
+    expect(pill.text()).toContain('Archived copy available');
+    expect(pill.classes()).toContain('tone-archived');
+    const archiveLink = wrapper.find(
+      `[data-test="${TEST_IDS.data_source_url_archive}"]`
+    );
+    expect(archiveLink.exists()).toBe(true);
+    expect(archiveLink.attributes('href')).toBe('https://web.archive.org/abc');
+  });
+
+  it('renders broken state when broken without archive', () => {
+    const wrapper = mount(UrlHealthPill, {
+      props: { urlStatus: 'broken', archiveUrl: null }
+    });
+    const pill = wrapper.find(
+      `[data-test="${TEST_IDS.data_source_url_health}"]`
+    );
+    expect(pill.text()).toContain('URL broken');
+    expect(pill.classes()).toContain('tone-broken');
+    expect(
+      wrapper.find(`[data-test="${TEST_IDS.data_source_url_archive}"]`).exists()
+    ).toBe(false);
+  });
+
+  it('is case-insensitive for status value', () => {
+    const wrapper = mount(UrlHealthPill, {
+      props: { urlStatus: 'OK', archiveUrl: null }
+    });
+    expect(
+      wrapper.find(`[data-test="${TEST_IDS.data_source_url_health}"]`).text()
+    ).toContain('URL healthy');
+  });
+});


### PR DESCRIPTION
## Summary
- Adds a color-coded URL Health pill next to the "Visit Data Source" button on the data source details page, surfacing backend-reported `url_status` + `internet_archive_url` so users know what to expect before clicking an external link.
- Three states: **healthy** (green), **archived** (amber, with link to the archived copy), **broken** (red). Renders nothing when no health data is available.
- Adds unit tests for the new `UrlHealthPill` component.

Closes #421

Depends on backend support landed in [data-source-manager#598](https://github.com/Police-Data-Accessibility-Project/data-source-manager/pull/598). Search-results indication (the optional bullet in the issue) is intentionally deferred to a follow-up to keep this PR focused.

## Test plan
- [x] `npm run test:unit` — 38 passed (including 5 new)
- [x] `npm run lint` — clean
- [ ] Manual: verify pill renders correctly in each of the three states against a dev data source with real `url_status` / `internet_archive_url` values

🤖 Generated with [Claude Code](https://claude.com/claude-code)