### PR TITLE
fix: mock annotation endpoints in E2E tests

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -4,3 +4,4 @@ coverage
 playwright-report
 test-results
 *.config.*
+.claude/worktrees

--- a/e2e/mocks/handlers/annotate.js
+++ b/e2e/mocks/handlers/annotate.js
@@ -85,14 +85,14 @@ export const annotateHandlers = [
     return HttpResponse.json(buildNextAnnotation(), { status: 200 });
   }),
 
-  // Anonymous POST submission
+  // Anonymous POST submission — returns the next annotation to label
   http.post('*/annotate/anonymous/:url_id', () => {
-    return HttpResponse.json({ session_id: TEST_SESSION_ID }, { status: 200 });
+    return HttpResponse.json(buildNextAnnotation(), { status: 200 });
   }),
 
-  // Authenticated POST submission
+  // Authenticated POST submission — returns the next annotation to label
   http.post('*/annotate/all/:url_id', () => {
-    return HttpResponse.json({}, { status: 200 });
+    return HttpResponse.json(buildNextAnnotation(), { status: 200 });
   }),
 
   // Anonymous-to-authenticated migration

--- a/e2e/mocks/handlers/annotate.js
+++ b/e2e/mocks/handlers/annotate.js
@@ -1,0 +1,113 @@
+import { http, HttpResponse } from 'msw';
+
+const TEST_SESSION_ID = '00000000-0000-4000-8000-000000000001';
+
+function buildNextAnnotation() {
+  return {
+    next_annotation: {
+      url_info: {
+        url: 'https://example.gov/police/records',
+        url_id: 1
+      },
+      html_info: {
+        index: 0,
+        url: 'https://example.gov/police/records',
+        url_path: '/police/records',
+        title: 'Example PD Records',
+        description: 'Public records portal for the Example Police Department.',
+        http_response: 200,
+        h1: 'Records Portal',
+        h2: '',
+        h3: '',
+        h4: '',
+        h5: '',
+        h6: '',
+        div: ''
+      },
+      batch_info: {
+        count_annotated: 0,
+        total_urls: 10,
+        count_not_annotated: 10
+      },
+      agency_suggestions: {
+        suggestions: [
+          {
+            id: 101,
+            display_name: 'Example Police Department',
+            user_count: 3,
+            robo_confidence: 0.92
+          }
+        ]
+      },
+      location_suggestions: {
+        suggestions: [
+          {
+            id: 201,
+            display_name: 'Example City, EX',
+            user_count: 2,
+            robo_confidence: 0.85
+          }
+        ]
+      },
+      url_type_suggestions: [{ url_type: 'data source', endorsement_count: 4 }],
+      record_type_suggestions: {
+        suggestions: [
+          {
+            record_type: 'Incident Reports',
+            user_count: 2,
+            robo_confidence: 0.8
+          }
+        ]
+      },
+      name_suggestions: {
+        suggestions: [
+          {
+            id: 301,
+            display_name: 'Daily Incident Log',
+            user_count: 1,
+            robo_count: 0
+          }
+        ]
+      }
+    },
+    session_id: TEST_SESSION_ID
+  };
+}
+
+export const annotateHandlers = [
+  // Anonymous GET — wildcard matches whatever VITE_SM_API_URL resolves to
+  http.get('*/annotate/anonymous', () => {
+    return HttpResponse.json(buildNextAnnotation(), { status: 200 });
+  }),
+
+  // Authenticated GET
+  http.get('*/annotate/all', () => {
+    return HttpResponse.json(buildNextAnnotation(), { status: 200 });
+  }),
+
+  // Anonymous POST submission
+  http.post('*/annotate/anonymous/:url_id', () => {
+    return HttpResponse.json({ session_id: TEST_SESSION_ID }, { status: 200 });
+  }),
+
+  // Authenticated POST submission
+  http.post('*/annotate/all/:url_id', () => {
+    return HttpResponse.json({}, { status: 200 });
+  }),
+
+  // Anonymous-to-authenticated migration
+  http.post('*/annotate/migrate', () => {
+    return HttpResponse.json({}, { status: 200 });
+  }),
+
+  // Authenticated user contributions
+  http.get('*/contributions/user', () => {
+    return HttpResponse.json(
+      {
+        count_validated: 0,
+        agreement: { record_type: 0, agency: 0, url_type: 0 }
+      },
+      { status: 200 }
+    );
+  })
+];

--- a/e2e/mocks/handlers/index.js
+++ b/e2e/mocks/handlers/index.js
@@ -1,8 +1,10 @@
+import { annotateHandlers } from './annotate';
 import { authHandlers } from './auth';
 import { dataRequestHandlers } from './data-requests';
 import { userHandlers } from './user';
 
 export const handlers = [
+  ...annotateHandlers,
   ...authHandlers,
   ...dataRequestHandlers,
   ...userHandlers


### PR DESCRIPTION
## Summary

- PR #422 (dev → main) consistently fails 25 annotation E2E tests on every retry. Same pattern holds for every Dev → Main PR in the repo's history.
- Root cause is environmental, not flake. `.github/scripts/set-e2e-env.sh` switches `VITE_SM_API_URL` based on PR base: PRs to `main` hit production source-collector, PRs to `dev` hit staging. `e2e/msw-setup.js` uses `onUnhandledRequest: 'bypass'`, and `e2e/mocks/handlers/` had no annotation handlers — so the wizard called a real backend that doesn't yet serve `/annotate/*` on prod, and the page never rendered.
- This PR adds MSW handlers for `GET/POST /annotate/anonymous`, `GET/POST /annotate/all`, `POST /annotate/migrate`, and `GET /contributions/user`. Wildcard URL patterns mean the same handlers intercept regardless of which source-collector base URL is configured.
- Also adds `.claude/worktrees` to `.prettierignore` so untracked agent scratch dirs don't trip the pre-commit hook.

Refs #425.

## Test plan

- [ ] CI green on this PR (against dev API — should pass since the dev API already works; the real test comes next)
- [ ] After merge, re-run E2E on PR #422 — the annotate suite should pass against prod API now that handlers intercept the calls
- [ ] Optionally: trigger E2E via `workflow_dispatch` with `test_url=https://pdap.io` for a stronger pre-merge signal

🤖 Generated with [Claude Code](https://claude.com/claude-code)